### PR TITLE
examples: add apps that uses rpmsg in kernelspace

### DIFF
--- a/examples/linux/rpmsg-mat-mul/Makefile
+++ b/examples/linux/rpmsg-mat-mul/Makefile
@@ -1,0 +1,18 @@
+
+APP = mat_mul_demo
+APP_OBJS = mat_mul_demo.o
+
+# Add any other object files to this list below
+
+
+all: $(APP)
+
+$(APP): $(APP_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(APP_OBJS) $(LDLIBS) -lpthread
+
+clean:
+	rm -rf $(APP) *.o
+
+%.o: %.c
+	$(CC) -c $(CFLAGS) -o $@ $<
+

--- a/examples/linux/rpmsg-mat-mul/README
+++ b/examples/linux/rpmsg-mat-mul/README
@@ -1,0 +1,15 @@
+app: mat_mul_demo
+
+Description:
+  This example demonstrate interprocessor communication using rpmsg framework
+  in the Linux kernelspace. Host (this) application generates two random matrices and send
+  them to remote processor using rpmsg framework in the Linux kernelspace and waits for
+  the response. Remote processor firmware receives both matrices and
+  multiplies them and sends result back to host processor.
+  Host processor prints the result on console after receiveing it.
+  If -n <number> option is passed, then above demo runs <number> times.
+  User can also pass custom endpoint information with -s (source address)
+  and -e (destination address) options as well.
+
+Remote processor firmware: Xilinx ZynqMP cortex-r5 platform
+  https://github.com/OpenAMP/open-amp/blob/main/apps/examples/matrix_multiply/matrix_multiply.c

--- a/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
+++ b/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
@@ -285,6 +285,17 @@ static void lookup_channel(char *out, struct rpmsg_endpoint_info *pep)
 	fprintf(stderr, "No dev file for %s in %s\n", pep->name, dpath);
 }
 
+void print_help(void)
+{
+	extern char *__progname;
+	printf("\r\nusage: %s [option: -d, -n, -s, -e]\r\n", __progname);
+	printf("-d - rpmsg device name\r\n");
+	printf("-n - number of times this demo is repeated\r\n");
+	printf("-s - source end point address\r\n");
+	printf("-e - destination end point address\r\n");
+	printf("\r\n");
+}
+
 int main(int argc, char *argv[])
 {
 	int ntimes = 1;
@@ -317,17 +328,17 @@ int main(int argc, char *argv[])
 			strncpy(rpmsg_dev, optarg, sizeof(rpmsg_dev));
 			break;
 		case 'n':
-			ntimes = atoi(optarg);
+			ntimes = strtol(optarg, NULL, 10);
 			break;
 		case 's':
-			eptinfo.src = atoi(optarg);
+			eptinfo.src = strtol(optarg, NULL, 10);
 			break;
 		case 'e':
-			eptinfo.dst = atoi(optarg);
+			eptinfo.dst = strtol(optarg, NULL, 10);
 			break;
 		default:
-			printf("getopt return unsupported option: -%c\n",opt);
-			break;
+			print_help();
+			return -EINVAL;
 		}
 	}
 

--- a/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
+++ b/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
@@ -1,0 +1,379 @@
+//SPDX-License-Identifier: BSD-3-Clause
+
+/*
+ * Sample demo application that showcases inter processor
+ * communication from linux userspace to a remote software
+ * context. The application generates random matrices and
+ * transmits them to the remote context over rpmsg. The
+ * remote application performs multiplication of matrices
+ * and transmits the results back to this application.
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <fcntl.h>
+#include <string.h>
+#include <linux/rpmsg.h>
+
+#define RPMSG_BUS_SYS "/sys/bus/rpmsg"
+
+#define PR_DBG(fmt, args ...) printf("%s():%u "fmt, __func__, __LINE__, ##args)
+#define SHUTDOWN_MSG    0xEF56A55A
+#define MATRIX_SIZE 6
+
+struct _matrix {
+	unsigned int size;
+	unsigned int elements[MATRIX_SIZE][MATRIX_SIZE];
+};
+
+static void matrix_print(struct _matrix *m)
+{
+	int i, j;
+
+	/* Generate two random matrices */
+	printf(" \r\n Host : Linux : Printing results \r\n");
+
+	for (i = 0; i < m->size; ++i) {
+		for (j = 0; j < m->size; ++j)
+			printf(" %d ", (unsigned int)m->elements[i][j]);
+		printf("\r\n");
+	}
+}
+
+static void generate_matrices(int num_matrices,
+				unsigned int matrix_size, void *p_data)
+{
+	int	i, j, k;
+	struct _matrix *p_matrix = p_data;
+	time_t	t;
+	unsigned long value;
+
+	srand((unsigned) time(&t));
+
+	for (i = 0; i < num_matrices; i++) {
+		/* Initialize workload */
+		p_matrix[i].size = matrix_size;
+
+		printf(" \r\n Host : Linux : Input matrix %d \r\n", i);
+		for (j = 0; j < matrix_size; j++) {
+			printf("\r\n");
+			for (k = 0; k < matrix_size; k++) {
+
+				value = (rand() & 0x7F);
+				value = value % 10;
+				p_matrix[i].elements[j][k] = value;
+				printf(" %d ",
+				(unsigned int)p_matrix[i].elements[j][k]);
+			}
+		}
+		printf("\r\n");
+	}
+
+}
+
+static int charfd = -1, fd;
+static struct _matrix i_matrix[2];
+static struct _matrix r_matrix;
+
+void matrix_mult(int ntimes)
+{
+	int i;
+
+	for (i=0; i < ntimes; i++){
+		generate_matrices(2, MATRIX_SIZE, i_matrix);
+
+		printf("%d: write rpmsg: %lu bytes\n", i, sizeof(i_matrix));
+		ssize_t rc = write(fd, i_matrix, sizeof(i_matrix));
+		if (rc < 0)
+			fprintf(stderr, "write,errno = %ld, %d\n", rc, errno);
+
+		puts("read results");
+		do {
+			rc = read(fd, &r_matrix, sizeof(r_matrix));
+		} while (rc < (int)sizeof(r_matrix));
+		matrix_print(&r_matrix);
+		printf("End of Matrix multiplication demo Round %d\n", i);
+	}
+}
+
+/*
+ * Probably an overkill to memset(.., sizeof(struct _matrix)) as
+ * the firmware looks for SHUTDOWN_MSG in the first 32 bits.
+ */
+void send_shutdown(int fd)
+{
+	memset(i_matrix, SHUTDOWN_MSG, sizeof(struct _matrix));
+	if (write(fd, i_matrix, sizeof(i_matrix)) < 0)
+		perror("write SHUTDOWN_MSG\n");
+}
+
+int app_rpmsg_create_ept(int rpfd, struct rpmsg_endpoint_info *eptinfo)
+{
+	int ret;
+
+	ret = ioctl(rpfd, RPMSG_CREATE_EPT_IOCTL, eptinfo);
+	if (ret)
+		perror("Failed to create endpoint.\n");
+	return ret;
+}
+
+static char *get_rpmsg_ept_dev_name(const char *rpmsg_char_name,
+				    const char *ept_name,
+				    char *ept_dev_name)
+{
+	char sys_rpmsg_ept_name_path[64];
+	char svc_name[64];
+	char *sys_rpmsg_path = "/sys/class/rpmsg";
+	FILE *fp;
+	int i;
+	int ept_name_len;
+
+	for (i = 0; i < 128; i++) {
+		sprintf(sys_rpmsg_ept_name_path, "%s/%s/rpmsg%d/name",
+			sys_rpmsg_path, rpmsg_char_name, i);
+		printf("checking %s\n", sys_rpmsg_ept_name_path);
+		if (access(sys_rpmsg_ept_name_path, F_OK) < 0)
+			continue;
+		fp = fopen(sys_rpmsg_ept_name_path, "r");
+		if (!fp) {
+			printf("failed to open %s\n", sys_rpmsg_ept_name_path);
+			break;
+		}
+		fgets(svc_name, sizeof(svc_name), fp);
+		fclose(fp);
+		printf("svc_name: %s.\n",svc_name);
+		ept_name_len = strlen(ept_name);
+		if (ept_name_len > sizeof(svc_name))
+			ept_name_len = sizeof(svc_name);
+		if (!strncmp(svc_name, ept_name, ept_name_len)) {
+			sprintf(ept_dev_name, "rpmsg%d", i);
+			return ept_dev_name;
+		}
+	}
+
+	printf("Not able to RPMsg endpoint file for %s:%s.\n",
+	       rpmsg_char_name, ept_name);
+	return NULL;
+}
+
+static int bind_rpmsg_chrdev(const char *rpmsg_dev_name)
+{
+	char fpath[256];
+	char *rpmsg_chdrv = "rpmsg_chrdev";
+	int fd;
+	int ret;
+
+	/* rpmsg dev overrides path */
+	sprintf(fpath, "%s/devices/%s/driver_override",
+		RPMSG_BUS_SYS, rpmsg_dev_name);
+	PR_DBG("open %s\n", fpath);
+	fd = open(fpath, O_WRONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s, %s\n",
+			fpath, strerror(errno));
+		return -EINVAL;
+	}
+	ret = write(fd, rpmsg_chdrv, strlen(rpmsg_chdrv) + 1);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to write %s to %s, %s\n",
+			rpmsg_chdrv, fpath, strerror(errno));
+		return -EINVAL;
+	}
+	close(fd);
+
+	/* bind the rpmsg device to rpmsg char driver */
+	sprintf(fpath, "%s/drivers/%s/bind", RPMSG_BUS_SYS, rpmsg_chdrv);
+	fd = open(fpath, O_WRONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s, %s\n",
+			fpath, strerror(errno));
+		return -EINVAL;
+	}
+	PR_DBG("write %s to %s\n", rpmsg_dev_name, fpath);
+	ret = write(fd, rpmsg_dev_name, strlen(rpmsg_dev_name) + 1);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to write %s to %s, %s\n",
+			rpmsg_dev_name, fpath, strerror(errno));
+		return -EINVAL;
+	}
+	close(fd);
+	return 0;
+}
+
+static int get_rpmsg_chrdev_fd(const char *rpmsg_dev_name,
+			       char *rpmsg_ctrl_name)
+{
+	char dpath[2*NAME_MAX];
+	DIR *dir;
+	struct dirent *ent;
+	int fd;
+
+	sprintf(dpath, "%s/devices/%s/rpmsg", RPMSG_BUS_SYS, rpmsg_dev_name);
+	PR_DBG("opendir %s\n", dpath);
+	dir = opendir(dpath);
+	if (dir == NULL) {
+		fprintf(stderr, "opendir %s, %s\n", dpath, strerror(errno));
+		return -EINVAL;
+	}
+	while ((ent = readdir(dir)) != NULL) {
+		if (!strncmp(ent->d_name, "rpmsg_ctrl", 10)) {
+			sprintf(dpath, "/dev/%s", ent->d_name);
+			closedir(dir);
+			PR_DBG("open %s\n", dpath);
+			fd = open(dpath, O_RDWR | O_NONBLOCK);
+			if (fd < 0) {
+				fprintf(stderr, "open %s, %s\n",
+					dpath, strerror(errno));
+				return fd;
+			}
+			sprintf(rpmsg_ctrl_name, "%s", ent->d_name);
+			return fd;
+		}
+	}
+
+	fprintf(stderr, "No rpmsg_ctrl file found in %s\n", dpath);
+	closedir(dir);
+	return -EINVAL;
+}
+
+static void set_src_dst(char *out, struct rpmsg_endpoint_info *pep)
+{
+	long dst = 0;
+	char *lastdot = strrchr(out, '.');
+
+	if (lastdot == NULL)
+		return;
+	dst = strtol(lastdot + 1, NULL, 10);
+	if ((errno == ERANGE && (dst == LONG_MAX || dst == LONG_MIN))
+	    || (errno != 0 && dst == 0)) {
+		return;
+	}
+	pep->dst = (unsigned int)dst;
+}
+
+/*
+ * return the first dirent matching rpmsg-openamp-demo-channel
+ * in /sys/bus/rpmsg/devices/ E.g.:
+ *	virtio0.rpmsg-openamp-demo-channel.-1.1024
+ */
+static void lookup_channel(char *out, struct rpmsg_endpoint_info *pep)
+{
+	char dpath[] = RPMSG_BUS_SYS "/devices";
+	struct dirent *ent;
+	DIR *dir = opendir(dpath);
+
+	if (dir == NULL) {
+		fprintf(stderr, "opendir %s, %s\n", dpath, strerror(errno));
+		return;
+	}
+	while ((ent = readdir(dir)) != NULL) {
+		if (strstr(ent->d_name, pep->name)) {
+			strncpy(out, ent->d_name, NAME_MAX);
+			set_src_dst(out, pep);
+			PR_DBG("using dev file: %s\n", out);
+			closedir(dir);
+			return;
+		}
+	}
+	closedir(dir);
+	fprintf(stderr, "No dev file for %s in %s\n", pep->name, dpath);
+}
+
+int main(int argc, char *argv[])
+{
+	int ntimes = 1;
+	int opt, ret;
+	char rpmsg_dev[NAME_MAX] = "virtio0.rpmsg-openamp-demo-channel.-1.0";
+	char rpmsg_char_name[16];
+	char fpath[2*NAME_MAX];
+	struct rpmsg_endpoint_info eptinfo = {
+		.name = "rpmsg-openamp-demo-channel", .src = 0, .dst = 0
+	};
+	char ept_dev_name[16];
+	char ept_dev_path[32];
+
+	printf("\r\n Matrix multiplication demo start \r\n");
+
+	/* Load rpmsg_char driver */
+	printf("\r\nHost>probe rpmsg_char\r\n");
+	ret = system("set -x; lsmod; modprobe rpmsg_char");
+	if (ret < 0) {
+		perror("Failed to load rpmsg_char driver.\n");
+		return -EINVAL;
+	}
+	system("modprobe rpmsg_ctrl");
+
+	lookup_channel(rpmsg_dev, &eptinfo);
+
+	while ((opt = getopt(argc, argv, "d:n:s:e:")) != -1) {
+		switch (opt) {
+		case 'd':
+			strncpy(rpmsg_dev, optarg, sizeof(rpmsg_dev));
+			break;
+		case 'n':
+			ntimes = atoi(optarg);
+			break;
+		case 's':
+			eptinfo.src = atoi(optarg);
+			break;
+		case 'e':
+			eptinfo.dst = atoi(optarg);
+			break;
+		default:
+			printf("getopt return unsupported option: -%c\n",opt);
+			break;
+		}
+	}
+
+	sprintf(fpath, RPMSG_BUS_SYS "/devices/%s", rpmsg_dev);
+	if (access(fpath, F_OK)) {
+		fprintf(stderr, "access(%s): %s\n", fpath, strerror(errno));
+		return -EINVAL;
+	}
+	ret = bind_rpmsg_chrdev(rpmsg_dev);
+	if (ret < 0)
+		return ret;
+	charfd = get_rpmsg_chrdev_fd(rpmsg_dev, rpmsg_char_name);
+	if (charfd < 0)
+		return charfd;
+
+	/* Create endpoint from rpmsg char driver */
+	PR_DBG("app_rpmsg_create_ept: %s[src=%#x,dst=%#x]\n",
+		eptinfo.name, eptinfo.src, eptinfo.dst);
+	ret = app_rpmsg_create_ept(charfd, &eptinfo);
+	if (ret) {
+		fprintf(stderr, "app_rpmsg_create_ept %s\n", strerror(errno));
+		return -EINVAL;
+	}
+	if (!get_rpmsg_ept_dev_name(rpmsg_char_name, eptinfo.name,
+				    ept_dev_name))
+		return -EINVAL;
+	sprintf(ept_dev_path, "/dev/%s", ept_dev_name);
+
+	printf("open %s\n", ept_dev_path);
+	fd = open(ept_dev_path, O_RDWR | O_NONBLOCK);
+	if (fd < 0) {
+		perror(ept_dev_path);
+		close(charfd);
+		return -1;
+	}
+
+	PR_DBG("matrix_mult(%d)\n", ntimes);
+	matrix_mult(ntimes);
+
+	send_shutdown(fd);
+	close(fd);
+	if (charfd >= 0)
+		close(charfd);
+
+	printf("\r\n Quitting application .. \r\n");
+	printf(" Matrix multiply application end \r\n");
+
+	return 0;
+}

--- a/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
+++ b/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
@@ -301,6 +301,7 @@ int main(int argc, char *argv[])
 	int ntimes = 1;
 	int opt, ret;
 	char rpmsg_dev[NAME_MAX] = "virtio0.rpmsg-openamp-demo-channel.-1.0";
+	char rpmsg_ctrl_dev_name[NAME_MAX] = "virtio0.rpmsg_ctrl.0.0";
 	char rpmsg_char_name[16];
 	char fpath[2*NAME_MAX];
 	struct rpmsg_endpoint_info eptinfo = {
@@ -350,9 +351,15 @@ int main(int argc, char *argv[])
 	ret = bind_rpmsg_chrdev(rpmsg_dev);
 	if (ret < 0)
 		return ret;
-	charfd = get_rpmsg_chrdev_fd(rpmsg_dev, rpmsg_char_name);
-	if (charfd < 0)
-		return charfd;
+
+	/* The Linux kernel >= 6.0 expects rpmsg_ctrl interface under virtio*.rpmsg_ctrl*.* dir */
+	charfd = get_rpmsg_chrdev_fd(rpmsg_ctrl_dev_name, rpmsg_char_name);
+	if (charfd < 0) {
+		/* look for previous interface */
+		charfd = get_rpmsg_chrdev_fd(rpmsg_dev, rpmsg_char_name);
+		if (charfd < 0)
+			return charfd;
+	}
 
 	/* Create endpoint from rpmsg char driver */
 	PR_DBG("app_rpmsg_create_ept: %s[src=%#x,dst=%#x]\n",

--- a/examples/linux/rpmsg-proxy-app/Makefile
+++ b/examples/linux/rpmsg-proxy-app/Makefile
@@ -1,0 +1,18 @@
+
+APP = proxy_app
+APP_OBJS = proxy_app.o
+
+# Add any other object files to this list below
+
+
+all: $(APP)
+
+$(APP): $(APP_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(APP_OBJS) $(LDLIBS)
+
+clean:
+	rm -rf $(APP) *.o
+
+%.o: %.c
+	$(CC) -c $(CFLAGS) -o $@ $<
+

--- a/examples/linux/rpmsg-proxy-app/README
+++ b/examples/linux/rpmsg-proxy-app/README
@@ -1,0 +1,44 @@
+app: proxy_app
+
+Description:
+
+  This app demonstrates two functionality
+  1) Use of host processor's file system by remote processor
+  2) remote processor's standard IO redirection to host processor's standard IO
+
+  1) This app allows remote processor to use file system of host processor. Host
+  processor file system acts as proxy of remote file system. Remote processor
+  can use open, read, write, close calls to interact with files on host
+  processor.
+
+  File "remote.file" is available after app exits on host side that is created by
+  remote processor that contains string "This is a test string being written to
+  file.." written by remote firmware. This demonstrates remote firmware can
+  create and write files on host side.
+
+  2) This application also demonstrates redirection of standard IO.
+  Remote processor can use host processor's stdin and stdout via proxy service
+  that is implemented on host side. This is achieved with open-amp proxy
+  service implemented here:
+  https://github.com/OpenAMP/open-amp/blob/main/lib/proxy/rpmsg_retarget.c
+  Remote side firmware uses two types of output functions to print message on
+  console 1) xil_printf i.e. using same UART console as of APU and 2) Standard
+  "printf" function that is re-directed to standard output of Host. Both function
+  uses different ways to output messages, but using same console.
+
+  This is interactive demo:
+  1. When the remote application prompts you to Enter name, enter any string without space.
+  2. When the remote application prompts you to Enter age , enter any integer.
+  3. When the remote application prompts you to Enter value for pi, enter any floating
+     point number.
+  After this, remote application will print all the inputs entered by user on console
+  of host processor.
+
+  Remote firmware's standard IO are redirected to host processor's standard IO.
+  So, when remote uses "printf" and "scanf" functions actually host processor's
+  console is used for printing output and scanning inputs. Host communicates with
+  remote via rpmsg_char driver and Remote communicates to Host via redirected
+  Standard IO.
+
+Remote processor firmware: Xilinx ZynqMP cortex-r5 platform
+  https://github.com/OpenAMP/open-amp/blob/main/apps/examples/rpc_demo/rpc_demo.c

--- a/examples/linux/rpmsg-proxy-app/proxy_app.c
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.c
@@ -1,0 +1,600 @@
+//SPDX-License-Identifier: BSD-3-Clause
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <time.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <signal.h>
+#include <unistd.h>
+#include "proxy_app.h"
+#include <linux/rpmsg.h>
+
+#define RPMSG_BUS_SYS "/sys/bus/rpmsg"
+
+#define RPC_BUFF_SIZE 512
+#define PROXY_ENDPOINT 127
+
+/* Initialization message ID */
+#define RPMG_INIT_MSG	"init_msg"
+
+struct _proxy_data {
+	int active;
+	int rpmsg_proxy_fd;
+	struct _sys_rpc *rpc;
+	struct _sys_rpc *rpc_response;
+	char *firmware_path;
+};
+
+static struct _proxy_data *proxy;
+char fw_dst_path[] = "/lib/firmware/image_rpc_demo";
+char sbuf[512];
+int r5_id = 0;
+
+int handle_open(struct _sys_rpc *rpc)
+{
+	int fd;
+	ssize_t bytes_written;
+
+	/* Open remote fd */
+
+	fd = open(rpc->sys_call_args.data, rpc->sys_call_args.int_field1,
+			rpc->sys_call_args.int_field2);
+
+	/* Construct rpc response */
+	proxy->rpc_response->id = OPEN_SYSCALL_ID;
+	proxy->rpc_response->sys_call_args.int_field1 = fd;
+	proxy->rpc_response->sys_call_args.int_field2 = 0; /*not used*/
+	proxy->rpc_response->sys_call_args.data_len = 0; /*not used*/
+
+	/* Transmit rpc response */
+	bytes_written = write(proxy->rpmsg_proxy_fd, proxy->rpc_response,
+				sizeof(struct _sys_rpc));
+
+	return (bytes_written != sizeof(struct _sys_rpc)) ? -1 : 0;
+}
+
+int handle_close(struct _sys_rpc *rpc)
+{
+	int retval;
+	ssize_t bytes_written;
+
+	/* Close remote fd */
+	retval = close(rpc->sys_call_args.int_field1);
+
+	/* Construct rpc response */
+	proxy->rpc_response->id = CLOSE_SYSCALL_ID;
+	proxy->rpc_response->sys_call_args.int_field1 = retval;
+	proxy->rpc_response->sys_call_args.int_field2 = 0; /*not used*/
+	proxy->rpc_response->sys_call_args.data_len = 0; /*not used*/
+
+	/* Transmit rpc response */
+	bytes_written = write(proxy->rpmsg_proxy_fd, proxy->rpc_response,
+				sizeof(struct _sys_rpc));
+
+	return (bytes_written != sizeof(struct _sys_rpc)) ? -1 : 0;
+}
+
+int handle_read(struct _sys_rpc *rpc)
+{
+	ssize_t bytes_read, bytes_written;
+	size_t  payload_size;
+	char *buff = proxy->rpc_response->sys_call_args.data;
+
+	if (rpc->sys_call_args.int_field1 == 0)
+		/* Perform read from fd for large size since this is a
+		STD/I request */
+		bytes_read = read(rpc->sys_call_args.int_field1, buff, 512);
+	else
+		/* Perform read from fd */
+		bytes_read = read(rpc->sys_call_args.int_field1, buff,
+					rpc->sys_call_args.int_field2);
+
+	/* Construct rpc response */
+	proxy->rpc_response->id = READ_SYSCALL_ID;
+	proxy->rpc_response->sys_call_args.int_field1 = bytes_read;
+	proxy->rpc_response->sys_call_args.int_field2 = 0; /* not used */
+	proxy->rpc_response->sys_call_args.data_len = bytes_read;
+
+	payload_size = sizeof(struct _sys_rpc) +
+			((bytes_read > 0) ? bytes_read : 0);
+
+	/* Transmit rpc response */
+	printf("%s: %d, %d\n", __func__, proxy->rpc_response->id, proxy->rpc_response->sys_call_args.int_field1);
+	bytes_written = write(proxy->rpmsg_proxy_fd, proxy->rpc_response,
+					payload_size);
+
+	return (bytes_written != payload_size) ? -1 : 0;
+}
+
+int handle_write(struct _sys_rpc *rpc)
+{
+	ssize_t bytes_written;
+
+	/* Write to remote fd */
+	bytes_written = write(rpc->sys_call_args.int_field1,
+				rpc->sys_call_args.data,
+				rpc->sys_call_args.int_field2);
+
+	/* Construct rpc response */
+	proxy->rpc_response->id = WRITE_SYSCALL_ID;
+	proxy->rpc_response->sys_call_args.int_field1 = bytes_written;
+	proxy->rpc_response->sys_call_args.int_field2 = 0; /*not used*/
+	proxy->rpc_response->sys_call_args.data_len = 0; /*not used*/
+
+	/* Transmit rpc response */
+	bytes_written = write(proxy->rpmsg_proxy_fd, proxy->rpc_response,
+				sizeof(struct _sys_rpc));
+
+	return (bytes_written != sizeof(struct _sys_rpc)) ? -1 : 0;
+}
+
+int handle_rpc(struct _sys_rpc *rpc)
+{
+	int retval;
+
+	/* Handle RPC */
+	switch ((int)(rpc->id)) {
+	case OPEN_SYSCALL_ID:
+	{
+		retval = handle_open(rpc);
+		break;
+	}
+	case CLOSE_SYSCALL_ID:
+	{
+		retval = handle_close(rpc);
+		break;
+	}
+	case READ_SYSCALL_ID:
+	{
+		retval = handle_read(rpc);
+		break;
+	}
+	case WRITE_SYSCALL_ID:
+	{
+		retval = handle_write(rpc);
+		break;
+	}
+	case TERM_SYSCALL_ID:
+	{
+		proxy->active = 0;
+		retval = 0;
+		break;
+	}
+	default:
+	{
+		printf("\r\nHost>Err:Invalid RPC sys call ID: %d! \r\n", rpc->id);
+		retval = -1;
+		break;
+	}
+	}
+
+	return retval;
+}
+
+/* write a string to an existing and writtable file */
+int file_write(char *path, char *str)
+{
+	int fd;
+	ssize_t bytes_written;
+	size_t str_sz;
+
+	fd = open(path, O_WRONLY);
+	if (fd == -1) {
+		perror("Error");
+		return -1;
+	}
+	str_sz = strlen(str);
+	bytes_written = write(fd, str, str_sz);
+	if (bytes_written != str_sz) {
+	        if (bytes_written == -1) {
+			perror("Error");
+		}
+		close(fd);
+		return -1;
+	}
+
+	if (-1 == close(fd)) {
+		perror("Error");
+		return -1;
+	}
+	return 0;
+}
+
+/* Stop remote CPU and Unload drivers */
+void stop_remote(void)
+{
+	system("modprobe -r rpmsg_char");
+}
+
+void exit_action_handler(int signum)
+{
+	proxy->active = 0;
+}
+
+static int app_rpmsg_create_ept(int rpfd, struct rpmsg_endpoint_info *eptinfo)
+{
+	int ret;
+
+	ret = ioctl(rpfd, RPMSG_CREATE_EPT_IOCTL, eptinfo);
+	if (ret)
+		perror("Failed to create endpoint.\n");
+	return ret;
+}
+
+static char *get_rpmsg_ept_dev_name(const char *rpmsg_char_name,
+				    const char *ept_name,
+				    char *ept_dev_name)
+{
+	char sys_rpmsg_ept_name_path[64];
+	char svc_name[64];
+	char *sys_rpmsg_path = "/sys/class/rpmsg";
+	FILE *fp;
+	int i;
+	int ept_name_len;
+
+	for (i = 0; i < 128; i++) {
+		sprintf(sys_rpmsg_ept_name_path, "%s/%s/rpmsg%d/name",
+			sys_rpmsg_path, rpmsg_char_name, i);
+		printf("checking %s\n", sys_rpmsg_ept_name_path);
+		if (access(sys_rpmsg_ept_name_path, F_OK) < 0)
+			continue;
+		fp = fopen(sys_rpmsg_ept_name_path, "r");
+		if (!fp) {
+			printf("failed to open %s\n", sys_rpmsg_ept_name_path);
+			break;
+		}
+		fgets(svc_name, sizeof(svc_name), fp);
+		fclose(fp);
+		printf("svc_name: %s.\n",svc_name);
+		ept_name_len = strlen(ept_name);
+		if (ept_name_len > sizeof(svc_name))
+			ept_name_len = sizeof(svc_name);
+		if (!strncmp(svc_name, ept_name, ept_name_len)) {
+			sprintf(ept_dev_name, "rpmsg%d", i);
+			return ept_dev_name;
+		}
+	}
+
+	printf("Not able to RPMsg endpoint file for %s:%s.\n",
+	       rpmsg_char_name, ept_name);
+	return NULL;
+}
+
+static int bind_rpmsg_chrdev(const char *rpmsg_dev_name)
+{
+	char fpath[256];
+	char *rpmsg_chdrv = "rpmsg_chrdev";
+	int fd;
+	int ret;
+
+	/* rpmsg dev overrides path */
+	sprintf(fpath, "%s/devices/%s/driver_override",
+		RPMSG_BUS_SYS, rpmsg_dev_name);
+	printf("open %s\n", fpath);
+	fd = open(fpath, O_WRONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s, %s\n",
+			fpath, strerror(errno));
+		return -EINVAL;
+	}
+	ret = write(fd, rpmsg_chdrv, strlen(rpmsg_chdrv) + 1);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to write %s to %s, %s\n",
+			rpmsg_chdrv, fpath, strerror(errno));
+		return -EINVAL;
+	}
+	close(fd);
+
+	/* bind the rpmsg device to rpmsg char driver */
+	sprintf(fpath, "%s/drivers/%s/bind", RPMSG_BUS_SYS, rpmsg_chdrv);
+	fd = open(fpath, O_WRONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s, %s\n",
+			fpath, strerror(errno));
+		return -EINVAL;
+	}
+	printf("write %s to %s\n", rpmsg_dev_name, fpath);
+	ret = write(fd, rpmsg_dev_name, strlen(rpmsg_dev_name) + 1);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to write %s to %s, %s\n",
+			rpmsg_dev_name, fpath, strerror(errno));
+		return -EINVAL;
+	}
+	close(fd);
+	return 0;
+}
+
+static int get_rpmsg_chrdev_fd(const char *rpmsg_dev_name,
+			       char *rpmsg_ctrl_name)
+{
+	char dpath[2*NAME_MAX];
+	DIR *dir;
+	struct dirent *ent;
+	int fd;
+
+	sprintf(dpath, "%s/devices/%s/rpmsg", RPMSG_BUS_SYS, rpmsg_dev_name);
+	printf("opendir %s\n", dpath);
+	dir = opendir(dpath);
+	if (dir == NULL) {
+		fprintf(stderr, "opendir %s, %s\n", dpath, strerror(errno));
+		return -EINVAL;
+	}
+	while ((ent = readdir(dir)) != NULL) {
+		if (!strncmp(ent->d_name, "rpmsg_ctrl", 10)) {
+			sprintf(dpath, "/dev/%s", ent->d_name);
+			printf("open %s\n", dpath);
+			fd = open(dpath, O_RDWR | O_NONBLOCK);
+			if (fd < 0) {
+				fprintf(stderr, "open %s, %s\n",
+					dpath, strerror(errno));
+				return fd;
+			}
+			sprintf(rpmsg_ctrl_name, "%s", ent->d_name);
+			return fd;
+		}
+	}
+
+	fprintf(stderr, "No rpmsg char dev file is found\n");
+	return -EINVAL;
+}
+
+static void set_src_dst(char *out, struct rpmsg_endpoint_info *pep)
+{
+	long dst = 0;
+	char *lastdot = strrchr(out, '.');
+
+	if (lastdot == NULL)
+		return;
+	dst = strtol(lastdot + 1, NULL, 10);
+	if ((errno == ERANGE && (dst == LONG_MAX || dst == LONG_MIN))
+	    || (errno != 0 && dst == 0)) {
+		return;
+	}
+	pep->dst = (unsigned int)dst;
+}
+
+/*
+ * return the first dirent matching rpmsg-openamp-demo-channel
+ * in /sys/bus/rpmsg/devices/ E.g.:
+ *	virtio0.rpmsg-openamp-demo-channel.-1.1024
+ */
+static int lookup_channel(char *out, struct rpmsg_endpoint_info *pep)
+{
+	char dpath[] = RPMSG_BUS_SYS "/devices";
+	struct dirent *ent;
+	DIR *dir = opendir(dpath);
+
+	if (dir == NULL) {
+		fprintf(stderr, "opendir %s, %s\n", dpath, strerror(errno));
+		return -EINVAL;
+	}
+	while ((ent = readdir(dir)) != NULL) {
+		if (strstr(ent->d_name, pep->name)) {
+			strncpy(out, ent->d_name, NAME_MAX);
+			set_src_dst(out, pep);
+			printf("using dev file: %s\n", out);
+			closedir(dir);
+			return 0;
+		}
+	}
+	closedir(dir);
+	fprintf(stderr, "No dev file for %s in %s\n", pep->name, dpath);
+	return -EINVAL;
+}
+
+void kill_action_handler(int signum)
+{
+	printf("\r\nHost>RPC service killed !!\r\n");
+
+	/* Close proxy rpmsg device */
+	close(proxy->rpmsg_proxy_fd);
+
+	/* Free up resources */
+	free(proxy->rpc);
+	free(proxy->rpc_response);
+	free(proxy);
+
+	/* Stop remote cpu and unload drivers */
+	stop_remote();
+}
+
+void display_help_msg(void)
+{
+	printf("\r\nLinux proxy application.\r\n");
+	printf("-v	 Displays proxy application version.\n");
+	printf("-c	 Whether to use RPMsg char driver.\n");
+	printf("-f	 Accepts path of firmware to load on remote core.\n");
+	printf("-r       Which remoteproc instance\n");
+	printf("-h	 Displays this help message.\n");
+}
+
+int main(int argc, char *argv[])
+{
+	struct sigaction exit_action;
+	struct sigaction kill_action;
+	int bytes_rcvd;
+	int opt = 0;
+	int ret = 0;
+	char *user_fw_path = 0;
+	char rpmsg_dev_name[NAME_MAX];
+	char rpmsg_char_name[16];
+	int rpmsg_char_fd = -1;
+	int ept_fd = -1;
+	struct rpmsg_endpoint_info eptinfo = {
+		.name = "rpmsg-openamp-demo-channel", .src = 0, .dst = 0
+	};
+	char ept_dev_name[16];
+	char ept_dev_path[32];
+
+	/* Initialize signalling infrastructure */
+	memset(&exit_action, 0, sizeof(struct sigaction));
+	memset(&kill_action, 0, sizeof(struct sigaction));
+	exit_action.sa_handler = exit_action_handler;
+	kill_action.sa_handler = kill_action_handler;
+	sigaction(SIGTERM, &exit_action, NULL);
+	sigaction(SIGINT, &exit_action, NULL);
+	sigaction(SIGKILL, &kill_action, NULL);
+	sigaction(SIGHUP, &kill_action, NULL);
+
+	while ((opt = getopt(argc, argv, "vhf:r:")) != -1) {
+		switch (opt) {
+		case 'f':
+			user_fw_path = optarg;
+			break;
+		case 'r':
+			r5_id = atoi(optarg);
+			if (r5_id != 0 && r5_id != 1) {
+				display_help_msg();
+				return -1;
+			}
+			break;
+		case 'v':
+			printf("\r\nLinux proxy application version 1.1\r\n");
+			return 0;
+		case 'h':
+			display_help_msg();
+			return 0;
+		default:
+			printf("getopt return unsupported option: -%c\n",opt);
+			break;
+		}
+	}
+
+	/* Bring up remote firmware */
+	printf("\r\nMaster>Loading remote firmware\r\n");
+	if (user_fw_path) {
+		sprintf(sbuf, "cp %s %s", user_fw_path, fw_dst_path);
+		system(sbuf);
+	}
+
+	/* Load rpmsg_char driver */
+	printf("\r\nHost>probe rpmsg_char\r\n");
+	ret = system("modprobe rpmsg_char");
+	if (ret < 0) {
+		perror("Failed to load rpmsg_char driver.\n");
+		ret = -EINVAL;
+		goto error0;
+	}
+
+	system("modprobe rpmsg_ctrl");
+
+	/* Wait for rpmsg dev to be probed */
+	sleep(1);
+	ret = lookup_channel(rpmsg_dev_name, &eptinfo);
+	if (ret < 0)
+		goto error0;
+
+	ret = bind_rpmsg_chrdev(rpmsg_dev_name);
+	if (ret < 0)
+		goto error0;
+	rpmsg_char_fd = get_rpmsg_chrdev_fd(rpmsg_dev_name, rpmsg_char_name);
+	if (rpmsg_char_fd < 0) {
+		ret = rpmsg_char_fd;
+		goto error0;
+	}
+
+	/* Create endpoint from rpmsg char driver */
+	printf("app_rpmsg_create_ept: %s[src=%#x,dst=%#x]\n",
+		eptinfo.name, eptinfo.src, eptinfo.dst);
+	ret = app_rpmsg_create_ept(rpmsg_char_fd, &eptinfo);
+	if (ret) {
+		printf("failed to create RPMsg endpoint.\n");
+		goto error0;
+	}
+	if (!get_rpmsg_ept_dev_name(rpmsg_char_name, eptinfo.name,
+				    ept_dev_name)) {
+		ret = -EINVAL;
+		goto error0;
+	}
+	sprintf(ept_dev_path, "/dev/%s", ept_dev_name);
+	ept_fd = open(ept_dev_path, O_RDWR | O_NONBLOCK);
+	if (ept_fd < 0) {
+		perror("Failed to open rpmsg device.");
+		ret = ept_fd;
+		goto error0;
+	}
+	/* Allocate memory for proxy data structure */
+	proxy = malloc(sizeof(struct _proxy_data));
+	if (proxy == NULL) {
+		fprintf(stderr, "\r\nHost>Failed to allocate memory.\r\n");
+		ret = -ENOMEM;
+		goto error0;
+	}
+	proxy->rpmsg_proxy_fd = ept_fd;
+	proxy->active = 1;
+
+	/* Allocate memory for rpc payloads */
+	proxy->rpc = malloc(RPC_BUFF_SIZE);
+	proxy->rpc_response = malloc(RPC_BUFF_SIZE);
+	if (proxy->rpc == NULL || proxy->rpc_response == NULL) {
+		fprintf(stderr, "\r\nHost>Failed to allocate memory.\r\n");
+		ret = -ENOMEM;
+		goto error0;
+	}
+
+	/* RPC service starts */
+	printf("\r\nHost>RPC service started !!\r\n");
+	/* Send init message to remote.
+	 * This is required otherwise, remote doesn't know the host
+	 * RPMsg endpoint
+	 */
+	ret = write(proxy->rpmsg_proxy_fd, RPMG_INIT_MSG,
+		    sizeof(RPMG_INIT_MSG));
+	if (ret < 0) {
+		printf("\r\nHost>Failed to send init message.\r\n");
+		goto error0;
+	}
+
+	/* Block on read for rpc requests from remote context */
+	do {
+		bytes_rcvd = read(proxy->rpmsg_proxy_fd, proxy->rpc,
+				  RPC_BUFF_SIZE);
+		if (bytes_rcvd < 0 && errno != EAGAIN) {
+			perror("Failed to read ept");
+			break;
+		}
+		/* Handle rpc */
+		if ( bytes_rcvd > 0 && handle_rpc(proxy->rpc)) {
+			printf("\nHost>Err:Handling remote procedure call!\n");
+			printf("\nrpc id %d\n", proxy->rpc->id);
+			printf("\nrpc int field1 %d\n",
+				proxy->rpc->sys_call_args.int_field1);
+			printf("\nrpc int field2 %d\n",
+				proxy->rpc->sys_call_args.int_field2);
+			break;
+		}
+	} while(proxy->active);
+
+	printf("\r\nHost>RPC service exiting !!\r\n");
+	ret = 0;
+
+	/* Close proxy rpmsg device */
+	close(proxy->rpmsg_proxy_fd);
+
+	/* Wait for other end to cleanup
+	 * Otherwise, virtio_rpmsg_bus can post msg with no recipient
+	 * warning as it can receive NS destroy after the rpmsg char
+	 * module is removed.
+	 */
+	sleep(1);
+
+	/* Free up resources */
+	free(proxy->rpc);
+	free(proxy->rpc_response);
+
+error0:
+	if (ept_fd >= 0)
+		close(ept_fd);
+	if (rpmsg_char_fd >= 0)
+		close(rpmsg_char_fd);
+	free(proxy);
+
+	stop_remote();
+
+	return ret;
+}

--- a/examples/linux/rpmsg-proxy-app/proxy_app.c
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.c
@@ -411,6 +411,7 @@ int main(int argc, char *argv[])
 	int ret = 0;
 	char *user_fw_path = 0;
 	char rpmsg_dev_name[NAME_MAX];
+	char rpmsg_ctrl_dev_name[NAME_MAX] = "virtio0.rpmsg_ctrl.0.0";
 	char rpmsg_char_name[16];
 	int rpmsg_char_fd = -1;
 	int ept_fd = -1;
@@ -450,10 +451,16 @@ int main(int argc, char *argv[])
 	ret = bind_rpmsg_chrdev(rpmsg_dev_name);
 	if (ret < 0)
 		goto error0;
-	rpmsg_char_fd = get_rpmsg_chrdev_fd(rpmsg_dev_name, rpmsg_char_name);
+
+	/* The Linux kernel version >= 6.0 uses rpmsg_ctrl from virtio*.rpmsg_ctrl* dir */
+	rpmsg_char_fd = get_rpmsg_chrdev_fd(rpmsg_ctrl_dev_name, rpmsg_char_name);
 	if (rpmsg_char_fd < 0) {
-		ret = rpmsg_char_fd;
-		goto error0;
+		/* may be the Linux kernel version is < 6.0, look for previous interface */
+		rpmsg_char_fd = get_rpmsg_chrdev_fd(rpmsg_dev_name, rpmsg_char_name);
+		if (rpmsg_char_fd < 0) {
+			ret = rpmsg_char_fd;
+			goto error0;
+		}
 	}
 
 	/* Create endpoint from rpmsg char driver */

--- a/examples/linux/rpmsg-proxy-app/proxy_app.c
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.c
@@ -33,7 +33,6 @@ struct _proxy_data {
 static struct _proxy_data *proxy;
 char fw_dst_path[] = "/lib/firmware/image_rpc_demo";
 char sbuf[512];
-int r5_id = 0;
 
 int handle_open(struct _sys_rpc *rpc)
 {
@@ -403,16 +402,6 @@ void kill_action_handler(int signum)
 	stop_remote();
 }
 
-void display_help_msg(void)
-{
-	printf("\r\nLinux proxy application.\r\n");
-	printf("-v	 Displays proxy application version.\n");
-	printf("-c	 Whether to use RPMsg char driver.\n");
-	printf("-f	 Accepts path of firmware to load on remote core.\n");
-	printf("-r       Which remoteproc instance\n");
-	printf("-h	 Displays this help message.\n");
-}
-
 int main(int argc, char *argv[])
 {
 	struct sigaction exit_action;
@@ -440,37 +429,6 @@ int main(int argc, char *argv[])
 	sigaction(SIGINT, &exit_action, NULL);
 	sigaction(SIGKILL, &kill_action, NULL);
 	sigaction(SIGHUP, &kill_action, NULL);
-
-	while ((opt = getopt(argc, argv, "vhf:r:")) != -1) {
-		switch (opt) {
-		case 'f':
-			user_fw_path = optarg;
-			break;
-		case 'r':
-			r5_id = atoi(optarg);
-			if (r5_id != 0 && r5_id != 1) {
-				display_help_msg();
-				return -1;
-			}
-			break;
-		case 'v':
-			printf("\r\nLinux proxy application version 1.1\r\n");
-			return 0;
-		case 'h':
-			display_help_msg();
-			return 0;
-		default:
-			printf("getopt return unsupported option: -%c\n",opt);
-			break;
-		}
-	}
-
-	/* Bring up remote firmware */
-	printf("\r\nMaster>Loading remote firmware\r\n");
-	if (user_fw_path) {
-		sprintf(sbuf, "cp %s %s", user_fw_path, fw_dst_path);
-		system(sbuf);
-	}
 
 	/* Load rpmsg_char driver */
 	printf("\r\nHost>probe rpmsg_char\r\n");

--- a/examples/linux/rpmsg-proxy-app/proxy_app.h
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.h
@@ -1,0 +1,33 @@
+#include <stdint.h>
+
+/* System call definitions */
+#define OPEN_SYSCALL_ID		1
+#define CLOSE_SYSCALL_ID	2
+#define WRITE_SYSCALL_ID	3
+#define READ_SYSCALL_ID		4
+#define ACK_STATUS_ID		5
+#define TERM_SYSCALL_ID		6
+
+
+#define FILE_NAME_LEN		50
+
+struct _rpc_data {
+	struct rpmsg_channel *rpmsg_chnl;
+	struct rpmsg_endpoint *rp_ept;
+	void *rpc_lock;
+	void *sync_lock;
+	void *data;
+};
+
+struct _sys_call_args {
+	int32_t int_field1;
+	int32_t int_field2;
+	uint32_t data_len;
+	char data[0];
+};
+
+/* System call rpc data structure */
+struct _sys_rpc {
+	uint32_t id;
+	struct _sys_call_args	sys_call_args;
+};


### PR DESCRIPTION
rpmsg-mat-mul
  This example demonstrates communication between host and remote processor
  using rpmsg in kernelspace

rpmsg-proxy-app
  This example demonstrates use of host file system by remote processor

Signed-off-by: Tanmay Shah <tanmay.shah@amd.com>