### PR TITLE
examples: rpmsg-proxy-app: fix rpmsg char dev path

### DIFF
--- a/examples/linux/rpmsg-proxy-app/proxy_app.c
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.c
@@ -410,7 +410,7 @@ int main(int argc, char *argv[])
 	int opt = 0;
 	int ret = 0;
 	char *user_fw_path = 0;
-	char rpmsg_dev_name[NAME_MAX];
+	char rpmsg_dev_name[NAME_MAX] = "virtio0.rpmsg-openamp-demo-channel.-1.0";
 	char rpmsg_ctrl_dev_name[NAME_MAX] = "virtio0.rpmsg_ctrl.0.0";
 	char rpmsg_char_name[16];
 	int rpmsg_char_fd = -1;


### PR DESCRIPTION
rpmsg_dev_name string needed to find correct rpmsg_char device. This is required for the linux kernel >= 6.0.

Signed-off-by: Tanmay Shah <tanmay.shah@amd.com>

Fixes: 32e714cd73b5d5b7b71a4bfe94a5d92e0cf456f6