### PR TITLE
examples: Modify README formatting

### DIFF
--- a/examples/linux/rpmsg-echo-test/README.md
+++ b/examples/linux/rpmsg-echo-test/README.md
@@ -1,36 +1,43 @@
-# app: echo_test
+# Demo: echo_test
 
-## Description:
-
-  This demo uses kernel rpmsg framework to send various size of data buffer to remote
+  This demo uses the Linux kernel rpmsg framework to send various size of data buffer to remote
   processor and validates integrity of received buffer from remote processor.
   If buffer data does not match, then number of different bytes are reported on
-  console
+  console.
 
-## Remote processor firmware: Xilinx ZynqMP cortex-r5 platform
+  Platform: Xilinx Zynq UltraScale+ MPSoC(a.k.a ZynqMP)
 
-  https://github.com/OpenAMP/open-amp/blob/main/apps/examples/echo/rpmsg-echo.c
+  Board: ZynqMP Zcu102
 
-## How to Build for Xilinx ZynqMP platform
-  * https://github.com/OpenAMP/open-amp#example-to-compile-zynq-ultrascale-mpsoc-r5-genericbaremetal-remote
+  ## Remote Processor firmware (image_echo_test)
+
+  * Remote processor firmware for Xilinx ZynqMP cortex-r5 platform based on: [rpmsg-echo.c](https://github.com/OpenAMP/open-amp/blob/main/apps/examples/echo/rpmsg-echo.c)
+
+  * Instructions to compile: [ZynqMP r5f generic baremetal](https://github.com/OpenAMP/open-amp/blob/main/README.md#example-to-compile-zynq-ultrascale-mpsoc-r5-genericbaremetal-remote)
+
   * RPU firmware elf file is expected in sdk at path: /lib/firmware/
-  * This build step needs Xilinx Vendor specific toolchain xsdb
 
-## How to run on zcu102 board/QEMU:
+  * Xilinx Vendor specific SDK is required to build RPU firmware: [Xilinx Petalinux](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/embedded-design-tools.html)
 
-Assume all the binaries are zcu102 board specific.
+  * More information is provided here: [Xilinx Wiki page for OpenAMP](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18841718/OpenAMP)
 
-   ##### Specify Echo Test Firmware to be loaded.
-   `echo image_echo_test > /sys/class/remoteproc/remoteproc0/firmware`
+  ## Run the demo
 
-   ##### Load and start target Firmware onto remote processor
-   `echo start > /sys/class/remoteproc/remoteproc0/state`
+  Assume all the binaries are board specific.
 
-   ##### check remote processor state
-   `cat /sys/class/remoteproc/remoteproc0/state`
+  ```
+  # Specify remote processor firmware to be loaded.
+  echo image_echo_test > /sys/class/remoteproc/remoteproc0/firmware
 
-   ##### Run echo_test application
-   `echo_test`
+  # Load and start target firmware onto remote processor
+  echo start > /sys/class/remoteproc/remoteproc0/state
 
-   ##### stop target firmware
-   `echo stop > /sys/class/remoteproc/remoteproc0/state`
+  # check remote processor state
+  cat /sys/class/remoteproc/remoteproc0/state
+
+  # Run echo_test application on host processor
+  echo_test
+
+  # Stop remote processor
+  echo stop > /sys/class/remoteproc/remoteproc0/state
+  ```

--- a/examples/linux/rpmsg-mat-mul/README.md
+++ b/examples/linux/rpmsg-mat-mul/README.md
@@ -1,6 +1,4 @@
-# app: mat_mul_demo
-
-## Description:
+# Demo: matrix multiply
 
   This example demonstrate interprocessor communication using rpmsg framework
   in the Linux kernelspace. Host (this) application generates two random matrices and send
@@ -12,26 +10,38 @@
   User can also pass custom endpoint information with -s (source address)
   and -e (destination address) options as well.
 
-## Remote processor firmware: Xilinx ZynqMP cortex-r5 platform
+  Platform: Xilinx Zynq UltraScale+ MPSoC(a.k.a ZynqMP) 
 
-  https://github.com/OpenAMP/open-amp/blob/main/apps/examples/matrix_multiply/matrix_multiply.c
+  Board: ZynqMP Zcu102
 
-## How to Build for Xilinx ZynqMP platform
-  * https://github.com/OpenAMP/open-amp#example-to-compile-zynq-ultrascale-mpsoc-r5-genericbaremetal-remote
+  ## Remote Processor firmware (image_matrix_multiply)
+
+  * Remote processor firmware for Xilinx ZynqMP cortex-r5 platform based on: [matrix_multiply.c](https://github.com/OpenAMP/open-amp/blob/main/apps/examples/matrix_multiply/matrix_multiply.c)
+
+  * Instructions to compile: [ZynqMP r5f generic baremetal](https://github.com/OpenAMP/open-amp/blob/main/README.md#example-to-compile-zynq-ultrascale-mpsoc-r5-genericbaremetal-remote)
+
   * RPU firmware elf file is expected in sdk at path: /lib/firmware/
-  * This build step needs Xilinx Vendor specific toolchain xsdb
 
-## How to run on zcu102 board/QEMU:
-Assume all the binaries are zcu102 board specific.
+  * Xilinx Vendor specific SDK is required to build RPU firmware: [Xilinx Petalinux](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/embedded-design-tools.html)
+  * More information is provided here: [Xilinx Wiki page for OpenAMP](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18841718/OpenAMP)
 
-  ##### Specify Matrix multiplication to get Firmare onto remote processor.
-  `echo image_matrix_multiply > /sys/class/remoteproc/remoteproc0/firmware`
+  ## Run the demo
 
-  ##### Load and start target Firmware onto remote processor.
-  `echo start > /sys/class/remoteproc/remoteproc0/state`
+  Assume all the binaries are board specific.
 
-  ##### Run Matrix multiplication test linux application.
-  `mat_mul_demo`
+  ```
+  # Specify remote processor firmware to be loaded.
+  echo image_matrix_multiply > /sys/class/remoteproc/remoteproc0/firmware
 
-  ##### Stop target firmware
-  `echo stop > /sys/class/remoteproc/remoteproc0/state`
+  # Load and start target Firmware onto remote processor
+  echo start > /sys/class/remoteproc/remoteproc0/state
+
+  # check remote processor state
+  cat /sys/class/remoteproc/remoteproc0/state
+
+  # Run Matrix multiplication application on host processor
+  mat_mul_demo
+
+  # Stop remote processor
+  echo stop > /sys/class/remoteproc/remoteproc0/state
+  ```

--- a/examples/linux/rpmsg-proxy-app/README.md
+++ b/examples/linux/rpmsg-proxy-app/README.md
@@ -1,12 +1,11 @@
-# app: proxy_app
-
-## Description:
+# Demo: proxy_app
 
   This app demonstrates two functionality
   1) Use of host processor's file system by remote processor
   2) remote processor's standard IO redirection to host processor's standard IO
 
-  1) This app allows remote processor to use file system of host processor. Host
+
+  case 1: This app allows remote processor to use file system of host processor. Host
   processor file system acts as proxy of remote file system. Remote processor
   can use open, read, write, close calls to interact with files on host
   processor.
@@ -16,11 +15,10 @@
   file.." written by remote firmware. This demonstrates remote firmware can
   create and write files on host side.
 
-  2) This application also demonstrates redirection of standard IO.
+  case 2: This application also demonstrates redirection of standard IO.
   Remote processor can use host processor's stdin and stdout via proxy service
   that is implemented on host side. This is achieved with open-amp proxy
-  service implemented here:
-  https://github.com/OpenAMP/open-amp/blob/main/lib/proxy/rpmsg_retarget.c
+  service implemented here: [rpmsg_retarget.c](https://github.com/OpenAMP/open-amp/blob/main/lib/proxy/rpmsg_retarget.c)
   Remote side firmware uses two types of output functions to print message on
   console 1) xil_printf i.e. using same UART console as of APU and 2) Standard
   "printf" function that is re-directed to standard output of Host. Both function
@@ -40,26 +38,36 @@
   remote via rpmsg_char driver and Remote communicates to Host via redirected
   Standard IO.
 
-## Remote processor firmware: Xilinx ZynqMP cortex-r5 platform
+  Platform: Xilinx Zynq UltraScale+ MPSoC(a.k.a ZynqMP) 
 
-  https://github.com/OpenAMP/open-amp/blob/main/apps/examples/rpc_demo/rpc_demo.c
+  Board: ZynqMP Zcu102
 
-## How to Build for Xilinx ZynqMP platform
-  * https://github.com/OpenAMP/open-amp#example-to-compile-zynq-ultrascale-mpsoc-r5-genericbaremetal-remote
+  ## Remote Processor firmware (image_rpc_demo)
+
+  * Remote processor firmware for Xilinx ZynqMP cortex-r5 platform based on: [rpc_demo.c](https://github.com/OpenAMP/open-amp/blob/main/apps/examples/rpc_demo/rpc_demo.c)
+
+  * Instructions to compile: [ZynqMP r5f generic baremetal](https://github.com/OpenAMP/open-amp/blob/main/README.md#example-to-compile-zynq-ultrascale-mpsoc-r5-genericbaremetal-remote)
+
   * RPU firmware elf file is expected in sdk at path: /lib/firmware/
-  * This build step needs Xilinx Vendor specific toolchain xsdb
 
-## How to run on zcu102 board/QEMU:
-Assume all the binaries are zcu102 board specific.
+  * Xilinx Vendor specific SDK is required to build RPU firmware: [Xilinx Petalinux](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/embedded-design-tools.html)
 
-##### Specify proxy application to get Firmare onto remote processor.
-`echo image_rpc_demo > /sys/class/remoteproc/remoteproc0/firmware`
+  * More information is provided here: [Xilinx Wiki page for OpenAMP](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18841718/OpenAMP)
 
-##### Load and start target Firmware onto remote processor.
-`echo start > /sys/class/remoteproc/remoteproc0/state`
+  ## Run the demo
 
-##### Run proxy application.
-`proxy_app`
+  Assume all the binaries are zcu102 board specific.
 
-##### Stop target firmware
-`echo stop > /sys/class/remoteproc/remoteproc0/state`
+  ```
+  # Specify remote processor firmware to be loaded.
+  echo image_rpc_demo > /sys/class/remoteproc/remoteproc0/firmware
+
+  # Load and start target Firmware onto remote processor.
+  echo start > /sys/class/remoteproc/remoteproc0/state
+
+  # Run proxy application.
+  proxy_app
+
+  # Stop target firmware
+  echo stop > /sys/class/remoteproc/remoteproc0/state
+  ```


### PR DESCRIPTION
Current README.md contains many titles with # prefix of each line. It generates lots of indexes when these README files are linked in openamp-docs repo.
Remove redundant # prefix. Only keep it for demo title, compilation steps and demo run steps. This way, openamp-docs generates minimal index in table of content.

Also re-edit README.md files for better presentation.

Signed-off-by: Tanmay Shah <tanmay.shah@amd.com>