### PR TITLE
examples: rpmsg-proxy-app: Update drivers being removed

### DIFF
--- a/examples/linux/rpmsg-echo-test/README.md
+++ b/examples/linux/rpmsg-echo-test/README.md
@@ -35,8 +35,20 @@
   # check remote processor state
   cat /sys/class/remoteproc/remoteproc0/state
 
+  # load rpmsg_char driver
+  modprobe rpmsg_char
+
+  # load rpmsg_ctrl driver
+  modprobe rpmsg_ctrl
+
   # Run echo_test application on host processor
   echo_test
+
+  # unload rpmsg_ctrl driver
+  modprobe -r rpmsg_ctrl
+
+  #unload rpmsg_char driver
+  modprobe -r rpmsg_char
 
   # Stop remote processor
   echo stop > /sys/class/remoteproc/remoteproc0/state

--- a/examples/linux/rpmsg-echo-test/echo_test.c
+++ b/examples/linux/rpmsg-echo-test/echo_test.c
@@ -265,21 +265,6 @@ int main(int argc, char *argv[])
 	char ept_dev_path[32];
 
 	printf("\r\n Echo test start \r\n");
-
-	/* Load rpmsg_char driver */
-	printf("\r\nHost>probe rpmsg_char\r\n");
-	ret = system("set -x; lsmod; modprobe rpmsg_char");
-	if (ret < 0) {
-		perror("Failed to load rpmsg_char driver.\n");
-		return -EINVAL;
-	}
-
-	/*
-	 * try probbing rpmsg_ctrl for new kernel, However it's not failure
-	 * if rpmsg_ctrl is not available in case of kernel < 6.0
-	 */
-	system("modprobe rpmsg_ctrl");
-
 	lookup_channel(rpmsg_dev, &eptinfo);
 
 	while ((opt = getopt(argc, argv, "d:n:s:e:")) != -1) {

--- a/examples/linux/rpmsg-mat-mul/README.md
+++ b/examples/linux/rpmsg-mat-mul/README.md
@@ -39,8 +39,20 @@
   # check remote processor state
   cat /sys/class/remoteproc/remoteproc0/state
 
+  # load rpmsg_char driver
+  modprobe rpmsg_char
+
+  # load rpmsg_ctrl driver
+  modprobe rpmsg_ctrl
+
   # Run Matrix multiplication application on host processor
   mat_mul_demo
+
+  # unload rpmsg_ctrl driver
+  modprobe -r rpmsg_ctrl
+
+  #unload rpmsg_char driver
+  modprobe -r rpmsg_char
 
   # Stop remote processor
   echo stop > /sys/class/remoteproc/remoteproc0/state

--- a/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
+++ b/examples/linux/rpmsg-mat-mul/mat_mul_demo.c
@@ -311,16 +311,6 @@ int main(int argc, char *argv[])
 	char ept_dev_path[32];
 
 	printf("\r\n Matrix multiplication demo start \r\n");
-
-	/* Load rpmsg_char driver */
-	printf("\r\nHost>probe rpmsg_char\r\n");
-	ret = system("set -x; lsmod; modprobe rpmsg_char");
-	if (ret < 0) {
-		perror("Failed to load rpmsg_char driver.\n");
-		return -EINVAL;
-	}
-	system("modprobe rpmsg_ctrl");
-
 	lookup_channel(rpmsg_dev, &eptinfo);
 
 	while ((opt = getopt(argc, argv, "d:n:s:e:")) != -1) {

--- a/examples/linux/rpmsg-proxy-app/README.md
+++ b/examples/linux/rpmsg-proxy-app/README.md
@@ -65,8 +65,20 @@
   # Load and start target Firmware onto remote processor.
   echo start > /sys/class/remoteproc/remoteproc0/state
 
+  # load rpmsg_char driver
+  modprobe rpmsg_char
+
+  # load rpmsg_ctrl driver
+  modprobe rpmsg_ctrl
+
   # Run proxy application.
   proxy_app
+
+  # unload rpmsg_ctrl driver
+  modprobe -r rpmsg_ctrl
+
+  #unload rpmsg_char driver
+  modprobe -r rpmsg_char
 
   # Stop target firmware
   echo stop > /sys/class/remoteproc/remoteproc0/state

--- a/examples/linux/rpmsg-proxy-app/proxy_app.c
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.c
@@ -204,12 +204,6 @@ int file_write(char *path, char *str)
 	return 0;
 }
 
-/* Stop remote CPU and Unload drivers */
-void stop_remote(void)
-{
-	system("modprobe -r rpmsg_char");
-}
-
 void exit_action_handler(int signum)
 {
 	proxy->active = 0;
@@ -397,9 +391,6 @@ void kill_action_handler(int signum)
 	free(proxy->rpc);
 	free(proxy->rpc_response);
 	free(proxy);
-
-	/* Stop remote cpu and unload drivers */
-	stop_remote();
 }
 
 int main(int argc, char *argv[])
@@ -430,17 +421,6 @@ int main(int argc, char *argv[])
 	sigaction(SIGINT, &exit_action, NULL);
 	sigaction(SIGKILL, &kill_action, NULL);
 	sigaction(SIGHUP, &kill_action, NULL);
-
-	/* Load rpmsg_char driver */
-	printf("\r\nHost>probe rpmsg_char\r\n");
-	ret = system("modprobe rpmsg_char");
-	if (ret < 0) {
-		perror("Failed to load rpmsg_char driver.\n");
-		ret = -EINVAL;
-		goto error0;
-	}
-
-	system("modprobe rpmsg_ctrl");
 
 	/* Wait for rpmsg dev to be probed */
 	sleep(1);
@@ -558,8 +538,6 @@ error0:
 	if (rpmsg_char_fd >= 0)
 		close(rpmsg_char_fd);
 	free(proxy);
-
-	stop_remote();
 
 	return ret;
 }


### PR DESCRIPTION
As rpmsg_char driver will still be in use by rpmsg_ctrl, update to remove drivers in correct order to remove error:
'modprobe: FATAL: Module rpmsg_char is in use.'

Signed-off-by: Ben Levinsky <ben.levinsky@amd.com>