### PR TITLE
examples: Linux: Fix rpmsg-utils README

### DIFF
--- a/examples/linux/rpmsg-utils/README
+++ b/examples/linux/rpmsg-utils/README
@@ -29,8 +29,7 @@ eptdestroy
 
 ping
 ====
-"rpmsg_ping" is a test binary that open a rpmsg chardev for a an echo
-test (write a patern and wait an answer)
+"rpmsg_ping" is a test binary that opens a rpmsg chardev for an echo test (write a pattern and wait an answer)
 
 rpmsgexportdev
 ==============


### PR DESCRIPTION
Fix typo in the documentation.