### PR TITLE
examples: zephyr: add qemu_cortex_r5 board support

### DIFF
--- a/examples/zephyr/rpmsg_multi_services/boards/qemu_cortex_r5.overlay
+++ b/examples/zephyr/rpmsg_multi_services/boards/qemu_cortex_r5.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	model = "QEMU Cortex-R5";
+	compatible = "xlnx,zynqmp-qemu";
+
+	chosen {
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+		zephyr,ipc = &rpu0_apu_mailbox;
+		zephyr,ipc_shm = &rpu0_ipc_shm;
+	};
+
+	reserved-memory {
+		compatible = "reserved-memory";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		status = "okay";
+		ranges;
+
+		rpu0_ipc_shm: memory@3ed40000 {
+			reg = <0x3ed40000 DT_SIZE_K(512)>;
+		};
+	};
+};
+
+&rpu0_ipi {
+	status = "okay";
+};
+
+&rpu0_apu_mailbox {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <99999901>;
+};
+
+&ttc0 {
+	status = "okay";
+	clock-frequency = <5000000>;
+};
+
+/delete-node/ &uart0;
+/delete-node/ &gem0;
+/delete-node/ &gem1;
+/delete-node/ &gem2;
+/delete-node/ &gem3;

--- a/examples/zephyr/rpmsg_multi_services/src/sample.yaml
+++ b/examples/zephyr/rpmsg_multi_services/src/sample.yaml
@@ -6,4 +6,5 @@ tests:
     sample.subsys.ipc.openamp_rs_table:
         build_only: true
         platform_allow: stm32mp157c_dk2
+        platform_allow: qemu_cortex_r5
         tags: ipm


### PR DESCRIPTION
Add dt overlay with zephyr,ipc and zephyr,ipc_shm nodes for AMD-xilinx zynqmp platform.

This PR depends on and should be merged after Zephy IPM driver PR: https://github.com/zephyrproject-rtos/zephyr/pull/61008



