### PR TITLE
examples: zephyr: add kv260_r5 board support

### DIFF
--- a/examples/zephyr/rpmsg_multi_services/boards/kv260_r5.overlay
+++ b/examples/zephyr/rpmsg_multi_services/boards/kv260_r5.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	model = "KV260 Cortex-R5";
+	compatible = "xlnx,zynqmp-r5";
+
+	chosen {
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+		zephyr,ipc = &rpu0_apu_mailbox;
+		zephyr,ipc_shm = &rpu0_ipc_shm;
+	};
+
+	reserved-memory {
+		compatible = "reserved-memory";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		status = "okay";
+		ranges;
+
+		rpu0_ipc_shm: memory@3ed40000 {
+			reg = <0x3ed40000 DT_SIZE_K(512)>;
+		};
+	};
+};
+
+&rpu0_ipi {
+	status = "okay";
+};
+
+&rpu0_apu_mailbox {
+	status = "okay";
+};
+
+/delete-node/ &uart0;
+/delete-node/ &gem0;
+/delete-node/ &gem1;
+/delete-node/ &gem2;
+/delete-node/ &gem3;

--- a/examples/zephyr/rpmsg_multi_services/src/sample.yaml
+++ b/examples/zephyr/rpmsg_multi_services/src/sample.yaml
@@ -7,4 +7,5 @@ tests:
         build_only: true
         platform_allow: stm32mp157c_dk2
         platform_allow: qemu_cortex_r5
+        platform_allow: kv260_r5
         tags: ipm


### PR DESCRIPTION
Add dt overlay with zephyr,ipc and zephyr,ipc_shm nodes for AMD-xilinx zynqmp based kv260 board.