### PR TITLE
Support building zephyr with upstream open-amp and libmetal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -5,6 +5,8 @@ manifest:
   remotes:
     - name: openamp
       url-base: https://github.com/OpenAMP
+    - name: zephyr
+      url-base: https://github.com/zephyrproject-rtos
   defaults:
     remote: openamp
 
@@ -12,7 +14,7 @@ manifest:
     path: openamp-system-reference
 
   projects:
-    - name: openamp-zephyr-staging
-      path: zephyr
-      revision: v3.4-branch
+    - name: zephyr
+      remote: zephyr
+      revision: v3.5.0
       import: true

--- a/west.yml
+++ b/west.yml
@@ -18,3 +18,17 @@ manifest:
       remote: zephyr
       revision: v3.5.0
       import: true
+
+    # as we use the same names as in the zephyr manifest,
+    # our definitions eclipse their's
+    - name: libmetal
+      revision: main
+
+    - name: open-amp
+      revision: main
+
+    # however, our version does not have the zephyr module glue
+    # so bring in our custom version that integrates both libraries
+    # as a single zephyr module
+    - name: openamp-zephyr-modules
+      revision: main


### PR DESCRIPTION
Prototype stage only.

TODO:
DONE: modify to work on Windows also
DONE: Get rid of wam remote stuff
WIP will be a different PR: Add CI github action workflow