### PR TITLE
examples: zephyr: Switch main return type from void to int

### DIFF
--- a/examples/zephyr/dual_qemu_ivshmem/host/src/main.c
+++ b/examples/zephyr/dual_qemu_ivshmem/host/src/main.c
@@ -38,7 +38,7 @@ void main(void)
 
 	if (!rpmsg_dev) {
 		printf("Could not get the RPMsg device for IVSHMEM backend!\n");
-		return;
+		return -1;
 	}
 
 	/* Creates the RPMSg endpoint to communicate with the remote side.
@@ -48,10 +48,12 @@ void main(void)
 			endpoint_cb, rpmsg_service_unbind);
 	if (status != 0) {
 		printf("rpmsg_create_ept failed %d\n", status);
-		return;
+		return status;
 	}
 
 	printf("Host Side, the communication over RPMsg is ready to use!\n");
+
+	return 0;
 }
 
 static int cmd_rpmsg_ivshmem_send(const struct shell *sh, size_t argc, char **argv)

--- a/examples/zephyr/dual_qemu_ivshmem/remote/src/main.c
+++ b/examples/zephyr/dual_qemu_ivshmem/remote/src/main.c
@@ -31,13 +31,13 @@ static void rpmsg_service_unbind(struct rpmsg_endpoint *ept)
 {
 }
 
-void main(void)
+int main(void)
 {
 	rpmsg_dev = get_rpmsg_ivshmem_device();
 
 	if (!rpmsg_dev) {
 		printf("Could not get the RPMsg device for IVSHMEM backend!\n");
-		return;
+		return -1;
 	}
 
 	/* Setup the endpoint, this will notify the host side and allow it
@@ -47,8 +47,10 @@ void main(void)
 			RPMSG_ADDR_ANY, endpoint_cb, rpmsg_service_unbind);
 	if (status != 0) {
 		printf("rpmsg_create_ept failed %d\n", status);
-		return;
+		return status;
 	}
 
 	printf("Remote Side, the communication over RPMsg is ready to use!\n");
+
+	return 0;
 }

--- a/examples/zephyr/rpmsg_multi_services/src/main_remote.c
+++ b/examples/zephyr/rpmsg_multi_services/src/main_remote.c
@@ -477,7 +477,7 @@ task_end:
 	printk("OpenAMP demo ended\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("Starting application threads!\n");
 	k_thread_create(&thread_mng_data, thread_mng_stack, APP_TASK_STACK_SIZE,
@@ -492,4 +492,6 @@ void main(void)
 	k_thread_create(&thread_raw_data, thread_raw_stack, APP_TASK_STACK_SIZE * 2,
 			(k_thread_entry_t)app_rpmsg_raw,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+
+	return 0;
 }


### PR DESCRIPTION
Zephyr requires now a int main return.

This fixes build warning:
zephy_rpmsg_multi_services/openamp-system-reference/examples/zephyr/rpmsg_multi_services/src/main_remote.c:480:6: warning: return type of 'main' is not 'int' [-Wmain]
  480 | void main(void)
      |      ^~~~