### PR TITLE
zephyr: fixup kv260_r5 DT memory until it can be fixed in Zephyr

### DIFF
--- a/examples/zephyr/rpmsg_multi_services/boards/kv260_r5.overlay
+++ b/examples/zephyr/rpmsg_multi_services/boards/kv260_r5.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "zynqmp_r5_override.dtsi"
+
 / {
 	model = "KV260 Cortex-R5";
 	compatible = "xlnx,zynqmp-r5";

--- a/examples/zephyr/rpmsg_multi_services/boards/qemu_cortex_r5.overlay
+++ b/examples/zephyr/rpmsg_multi_services/boards/qemu_cortex_r5.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "zynqmp_r5_override.dtsi"
+
 / {
 	model = "QEMU Cortex-R5";
 	compatible = "xlnx,zynqmp-qemu";

--- a/examples/zephyr/rpmsg_multi_services/boards/zynqmp_r5_override.dtsi
+++ b/examples/zephyr/rpmsg_multi_services/boards/zynqmp_r5_override.dtsi
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This file should do away once Zephyr has been adjusted for better memory
+ * configuration for zynqmp_r5
+ */
+
+/ {
+	chosen {
+		/* override zephyr for now until definitions can be fixed upstream */
+		zephyr,sram = &tcm_lockstep;
+
+		/* flash0 is QSPI XIP at offset 0 and is unlikely to be appropriate */
+		/delete-property/ zephyr,flash;
+	};
+
+	soc {
+		tcm_lockstep: memory@0 {
+			compatible = "mmio-sram";
+			reg = <0 DT_SIZE_K(256)>;
+		};
+    };
+};


### PR DESCRIPTION
We are currently using Zephyr v3.5.0.
The memory definitions for kv260_r5 are inappropriate for general usage and for ours.

The current flash definition refers to the QSPI XIP area of the zynqmp. This is unlikely to be appropriate to use in the general case.  The current usage also assume use at offset 0 in the QSPI which is even less likely to be appropriate.  It is OK zynqmp_r5 to define this (perhaps with the name of qspi-xip) but it should not be selected as the default for flash. Let people that needs this opt into it.

For now we disable the zephyr,flash choice.  This does not eliminate the memory report line but it at least shows a region size of 0.

Likewise for the definition of RAM.  Zynqmp_r5 defines 64MB of RAM starting at offset 0.  This would be a mix of TCM and DDR depending on the R5 mode split vs lockstep.  In lockstep, DDR would be used for anything >=256K. For split mode DDR would be used for 64K to 128K-1 and for >=198K.

Using DDR like this is dangerous if another OS is running on the A53s. Linux for example does not reserve this early DDR memory for use by the the R5(s).

For now assume lockstep (only mode supported by Zephyr v3.5.0) as provide a new memory definition for combined TCM and use it for RAM.