### PR TITLE
Zcu102 dts update 2023.2

### DIFF
--- a/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
@@ -125,6 +125,32 @@
 			xlnx,ipi-id = <0x04>;
 			phandle = <0x0a>;
 		};
+
+		ipi_mailbox_rpu0: mailbox@ff990040 {
+			reg = <0x00 0xff990040 0x00 0x20>,
+			      <0x00 0xff990060 0x00 0x20>,
+			      <0x00 0xff990200 0x00 0x20>,
+			      < 0x00 0xff990220 0x00 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x01>;
+		};
+
+		ipi_mailbox_rpu1: mailbox@ff990080 {
+			reg = <0x00 0xff990080 0x00 0x20>,
+			      <0x00 0xff9900a0 0x00 0x20>,
+			      <0x00 0xff990400 0x00 0x20>,
+			      <0x00 0xff990420 0x00 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x02>;
+		};
 	};
 
 	dcc {
@@ -591,6 +617,30 @@
 		ranges;
 		phandle = <0x57>;
 	};
+
+	remoteproc {
+		compatible = "xlnx,zynqmp-r5fss";
+		xlnx,cluster-mode = <1>;
+
+		r5f-0 {
+			compatible = "xlnx,zynqmp-r5f";
+			power-domains = <0x12 0x7>;
+			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
+					<&rpu0vdev0vring1>, <&rpu0vdev0buffer>;
+			mboxes = <&ipi_mailbox_rpu0 0>, <&ipi_mailbox_rpu0 1>;
+			mbox-names = "tx", "rx";
+		};
+
+		r5f-1 {
+			compatible = "xlnx,zynqmp-r5f";
+			power-domains = <0x12 0x8>;
+			memory-region = <&rproc_1_fw_image>, <&rpu1vdev1vring0>,
+					<&rpu1vdev1vring1>, <&rpu1vdev1buffer>;
+			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
+			mbox-names = "tx", "rx";
+		};
+	};
+
 
 	axi {
 		compatible = "simple-bus";
@@ -2421,6 +2471,54 @@
 	memory@0 {
 		device_type = "memory";
 		reg = <0x00 0x00 0x00 0x7ff00000 0x08 0x00 0x00 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		rproc_0_fw_image: memory@3ed00000 {
+			no-map;
+			reg = <0x0 0x3ed00000 0x0 0x40000>;
+		};
+
+		rpu0vdev0vring0: vdev0vring0@3ed40000 {
+			no-map;
+			reg = <0x00 0x3ed40000 0x00 0x4000>;
+		};
+
+		rpu0vdev0vring1: vdev0vring1@3ed44000 {
+			no-map;
+			reg = <0x00 0x3ed44000 0x00 0x4000>;
+		};
+
+		rpu0vdev0buffer: vdev0buffer@3ed48000 {
+			no-map;
+			compatible = "shared-dma-pool";
+			reg = <0x00 0x3ed48000 0x00 0x100000>;
+		};
+
+		rproc_1_fw_image: memory@3ef00000 {
+			no-map;
+			reg = <0x0 0x3ef00000 0x0 0x40000>;
+		};
+
+		rpu1vdev1vring0: vdev1vring0@3ef40000 {
+			no-map;
+			reg = <0x00 0x3ef40000 0x00 0x4000>;
+		};
+
+		rpu1vdev1vring1: vdev1vring1@3ef44000 {
+			no-map;
+			reg = <0x00 0x3ef44000 0x00 0x4000>;
+		};
+
+		rpu1vdev1buffer: vdev1buffer@3ef48000 {
+			no-map;
+			compatible = "shared-dma-pool";
+			reg = <0x00 0x3ef48000 0x00 0x100000>;
+		};
 	};
 
 	__symbols__ {

--- a/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
@@ -17,8 +17,9 @@
 			operating-points-v2 = <0x01>;
 			reg = <0x00>;
 			cpu-idle-states = <0x02>;
-			clocks = <0x03 0x0a>;
-			phandle = <0x44>;
+			next-level-cache = <0x03>;
+			clocks = <0x04 0x0a>;
+			phandle = <0x06>;
 		};
 
 		cpu@1 {
@@ -28,7 +29,8 @@
 			reg = <0x01>;
 			operating-points-v2 = <0x01>;
 			cpu-idle-states = <0x02>;
-			phandle = <0x45>;
+			next-level-cache = <0x03>;
+			phandle = <0x07>;
 		};
 
 		cpu@2 {
@@ -38,7 +40,8 @@
 			reg = <0x02>;
 			operating-points-v2 = <0x01>;
 			cpu-idle-states = <0x02>;
-			phandle = <0x46>;
+			next-level-cache = <0x03>;
+			phandle = <0x08>;
 		};
 
 		cpu@3 {
@@ -48,7 +51,14 @@
 			reg = <0x03>;
 			operating-points-v2 = <0x01>;
 			cpu-idle-states = <0x02>;
-			phandle = <0x47>;
+			next-level-cache = <0x03>;
+			phandle = <0x09>;
+		};
+
+		l2-cache {
+			compatible = "cache";
+			cache-level = <0x02>;
+			phandle = <0x03>;
 		};
 
 		idle-states {
@@ -66,7 +76,7 @@
 		};
 	};
 
-	cpu-opp-table {
+	opp-table-cpu {
 		compatible = "operating-points-v2";
 		opp-shared;
 		phandle = <0x01>;
@@ -96,24 +106,24 @@
 		};
 	};
 
-	zynqmp_ipi {
+	zynqmp-ipi {
 		u-boot,dm-pre-reloc;
 		compatible = "xlnx,zynqmp-ipi-mailbox";
-		interrupt-parent = <0x04>;
+		interrupt-parent = <0x05>;
 		interrupts = <0x00 0x23 0x04>;
 		xlnx,ipi-id = <0x00>;
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-		phandle = <0x48>;
+		phandle = <0x42>;
 
-		mailbox@ff990400 {
+		mailbox@ff9905c0 {
 			u-boot,dm-pre-reloc;
 			reg = <0x00 0xff9905c0 0x00 0x20 0x00 0xff9905e0 0x00 0x20 0x00 0xff990e80 0x00 0x20 0x00 0xff990ea0 0x00 0x20>;
 			reg-names = "local_request_region\0local_response_region\0remote_request_region\0remote_response_region";
 			#mbox-cells = <0x01>;
 			xlnx,ipi-id = <0x04>;
-			phandle = <0x05>;
+			phandle = <0x0a>;
 		};
 	};
 
@@ -121,13 +131,14 @@
 		compatible = "arm,dcc";
 		status = "disabled";
 		u-boot,dm-pre-reloc;
-		phandle = <0x49>;
+		phandle = <0x43>;
 	};
 
 	pmu {
 		compatible = "arm,armv8-pmuv3";
-		interrupt-parent = <0x04>;
+		interrupt-parent = <0x05>;
 		interrupts = <0x00 0x8f 0x04 0x00 0x90 0x04 0x00 0x91 0x04 0x00 0x92 0x04>;
+		interrupt-affinity = <0x06 0x07 0x08 0x09>;
 	};
 
 	psci {
@@ -142,134 +153,127 @@
 			u-boot,dm-pre-reloc;
 			method = "smc";
 			#power-domain-cells = <0x01>;
-			phandle = <0x0c>;
+			phandle = <0x12>;
 
 			zynqmp-power {
 				u-boot,dm-pre-reloc;
 				compatible = "xlnx,zynqmp-power";
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupts = <0x00 0x23 0x04>;
-				mboxes = <0x05 0x00 0x05 0x01>;
+				mboxes = <0x0a 0x00 0x0a 0x01>;
 				mbox-names = "tx\0rx";
-				phandle = <0x4a>;
+				phandle = <0x44>;
 			};
 
-			nvmem_firmware {
+			nvmem-firmware {
 				compatible = "xlnx,zynqmp-nvmem-fw";
 				#address-cells = <0x01>;
 				#size-cells = <0x01>;
 
-				soc_revision@0 {
+				soc-revision@0 {
 					reg = <0x00 0x04>;
+					phandle = <0x45>;
+				};
+
+				efuse-dna@c {
+					reg = <0x0c 0x0c>;
+					phandle = <0x46>;
+				};
+
+				efuse-usr0@20 {
+					reg = <0x20 0x04>;
+					phandle = <0x47>;
+				};
+
+				efuse-usr1@24 {
+					reg = <0x24 0x04>;
+					phandle = <0x48>;
+				};
+
+				efuse-usr2@28 {
+					reg = <0x28 0x04>;
+					phandle = <0x49>;
+				};
+
+				efuse-usr3@2c {
+					reg = <0x2c 0x04>;
+					phandle = <0x4a>;
+				};
+
+				efuse-usr4@30 {
+					reg = <0x30 0x04>;
 					phandle = <0x4b>;
 				};
 
-				efuse_dna@c {
-					reg = <0x0c 0x0c>;
+				efuse-usr5@34 {
+					reg = <0x34 0x04>;
 					phandle = <0x4c>;
 				};
 
-				efuse_usr0@20 {
-					reg = <0x20 0x04>;
+				efuse-usr6@38 {
+					reg = <0x38 0x04>;
 					phandle = <0x4d>;
 				};
 
-				efuse_usr1@24 {
-					reg = <0x24 0x04>;
+				efuse-usr7@3c {
+					reg = <0x3c 0x04>;
 					phandle = <0x4e>;
 				};
 
-				efuse_usr2@28 {
-					reg = <0x28 0x04>;
+				efuse-miscusr@40 {
+					reg = <0x40 0x04>;
 					phandle = <0x4f>;
 				};
 
-				efuse_usr3@2c {
-					reg = <0x2c 0x04>;
+				efuse-chash@50 {
+					reg = <0x50 0x04>;
 					phandle = <0x50>;
 				};
 
-				efuse_usr4@30 {
-					reg = <0x30 0x04>;
+				efuse-pufmisc@54 {
+					reg = <0x54 0x04>;
 					phandle = <0x51>;
 				};
 
-				efuse_usr5@34 {
-					reg = <0x34 0x04>;
+				efuse-sec@58 {
+					reg = <0x58 0x04>;
 					phandle = <0x52>;
 				};
 
-				efuse_usr6@38 {
-					reg = <0x38 0x04>;
+				efuse-spkid@5c {
+					reg = <0x5c 0x04>;
 					phandle = <0x53>;
 				};
 
-				efuse_usr7@3c {
-					reg = <0x3c 0x04>;
+				efuse-ppk0hash@a0 {
+					reg = <0xa0 0x30>;
 					phandle = <0x54>;
 				};
 
-				efuse_miscusr@40 {
-					reg = <0x40 0x04>;
-					phandle = <0x55>;
-				};
-
-				efuse_chash@50 {
-					reg = <0x50 0x04>;
-					phandle = <0x56>;
-				};
-
-				efuse_pufmisc@54 {
-					reg = <0x54 0x04>;
-					phandle = <0x57>;
-				};
-
-				efuse_sec@58 {
-					reg = <0x58 0x04>;
-					phandle = <0x58>;
-				};
-
-				efuse_spkid@5c {
-					reg = <0x5c 0x04>;
-					phandle = <0x59>;
-				};
-
-				efuse_ppk0hash@a0 {
-					reg = <0xa0 0x30>;
-					phandle = <0x5a>;
-				};
-
-				efuse_ppk1hash@d0 {
+				efuse-ppk1hash@d0 {
 					reg = <0xd0 0x30>;
-					phandle = <0x5b>;
+					phandle = <0x55>;
 				};
 			};
 
 			pcap {
 				compatible = "xlnx,zynqmp-pcap-fpga";
-				clock-names = "ref_clk";
-				clocks = <0x03 0x29>;
-				phandle = <0x0b>;
-			};
-
-			zynqmp-aes {
-				compatible = "xlnx,zynqmp-aes";
-				phandle = <0x5c>;
+				phandle = <0x10>;
 			};
 
 			reset-controller {
 				compatible = "xlnx,zynqmp-reset";
 				#reset-cells = <0x01>;
-				phandle = <0x0f>;
+				phandle = <0x11>;
 			};
 
 			pinctrl {
 				compatible = "xlnx,zynqmp-pinctrl";
 				status = "okay";
-				phandle = <0x5d>;
+				phandle = <0x56>;
 
 				i2c0-default {
-					phandle = <0x13>;
+					phandle = <0x19>;
 
 					mux {
 						groups = "i2c0_3_grp";
@@ -285,7 +289,7 @@
 				};
 
 				i2c0-gpio {
-					phandle = <0x14>;
+					phandle = <0x1a>;
 
 					mux {
 						groups = "gpio0_14_grp\0gpio0_15_grp";
@@ -300,7 +304,7 @@
 				};
 
 				i2c1-default {
-					phandle = <0x16>;
+					phandle = <0x1c>;
 
 					mux {
 						groups = "i2c1_4_grp";
@@ -316,7 +320,7 @@
 				};
 
 				i2c1-gpio {
-					phandle = <0x17>;
+					phandle = <0x1d>;
 
 					mux {
 						groups = "gpio0_16_grp\0gpio0_17_grp";
@@ -331,7 +335,7 @@
 				};
 
 				uart0-default {
-					phandle = <0x1e>;
+					phandle = <0x25>;
 
 					mux {
 						groups = "uart0_4_grp";
@@ -356,7 +360,7 @@
 				};
 
 				uart1-default {
-					phandle = <0x1f>;
+					phandle = <0x26>;
 
 					mux {
 						groups = "uart1_5_grp";
@@ -381,7 +385,7 @@
 				};
 
 				usb0-default {
-					phandle = <0x21>;
+					phandle = <0x28>;
 
 					mux {
 						groups = "usb0_0_grp";
@@ -390,23 +394,26 @@
 
 					conf {
 						groups = "usb0_0_grp";
-						slew-rate = <0x01>;
 						power-source = <0x01>;
 					};
 
 					conf-rx {
 						pins = "MIO52\0MIO53\0MIO55";
 						bias-high-impedance;
+						drive-strength = <0x0c>;
+						slew-rate = <0x00>;
 					};
 
 					conf-tx {
 						pins = "MIO54\0MIO56\0MIO57\0MIO58\0MIO59\0MIO60\0MIO61\0MIO62\0MIO63";
 						bias-disable;
+						drive-strength = <0x04>;
+						slew-rate = <0x01>;
 					};
 				};
 
 				gem3-default {
-					phandle = <0x11>;
+					phandle = <0x16>;
 
 					mux {
 						function = "ethernet3";
@@ -445,7 +452,7 @@
 				};
 
 				can1-default {
-					phandle = <0x0d>;
+					phandle = <0x13>;
 
 					mux {
 						function = "can1";
@@ -470,7 +477,7 @@
 				};
 
 				sdhci1-default {
-					phandle = <0x1d>;
+					phandle = <0x24>;
 
 					mux {
 						groups = "sdio1_0_grp";
@@ -512,7 +519,7 @@
 				};
 
 				gpio-default {
-					phandle = <0x12>;
+					phandle = <0x18>;
 
 					mux-sw {
 						function = "gpio0";
@@ -548,37 +555,27 @@
 				};
 			};
 
-			sha384 {
-				compatible = "xlnx,zynqmp-keccak-384";
-				phandle = <0x5e>;
-			};
-
-			zynqmp-rsa {
-				compatible = "xlnx,zynqmp-rsa";
-				phandle = <0x5f>;
-			};
-
 			gpio {
 				compatible = "xlnx,zynqmp-gpio-modepin";
 				gpio-controller;
 				#gpio-cells = <0x02>;
-				phandle = <0x20>;
+				phandle = <0x27>;
 			};
 
 			clock-controller {
 				u-boot,dm-pre-reloc;
 				#clock-cells = <0x01>;
 				compatible = "xlnx,zynqmp-clk";
-				clocks = <0x06 0x07 0x08 0x09 0x0a>;
+				clocks = <0x0b 0x0c 0x0d 0x0e 0x0f>;
 				clock-names = "pss_ref_clk\0video_clk\0pss_alt_ref_clk\0aux_ref_clk\0gt_crx_ref_clk";
-				phandle = <0x03>;
+				phandle = <0x04>;
 			};
 		};
 	};
 
 	timer {
 		compatible = "arm,armv8-timer";
-		interrupt-parent = <0x04>;
+		interrupt-parent = <0x05>;
 		interrupts = <0x01 0x0d 0xf08 0x01 0x0e 0xf08 0x01 0x0b 0xf08 0x01 0x0a 0xf08>;
 	};
 
@@ -588,11 +585,11 @@
 
 	fpga-full {
 		compatible = "fpga-region";
-		fpga-mgr = <0x0b>;
+		fpga-mgr = <0x10>;
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-		phandle = <0x60>;
+		phandle = <0x57>;
 	};
 
 	axi {
@@ -601,7 +598,7 @@
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-		phandle = <0x61>;
+		phandle = <0x58>;
 
 		can@ff060000 {
 			compatible = "xlnx,zynq-can-1.0";
@@ -609,12 +606,13 @@
 			clock-names = "can_clk\0pclk";
 			reg = <0x00 0xff060000 0x00 0x1000>;
 			interrupts = <0x00 0x17 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
-			power-domains = <0x0c 0x2f>;
-			clocks = <0x03 0x3f 0x03 0x1f>;
-			phandle = <0x62>;
+			resets = <0x11 0x28>;
+			power-domains = <0x12 0x2f>;
+			clocks = <0x04 0x3f 0x04 0x1f>;
+			phandle = <0x59>;
 		};
 
 		can@ff070000 {
@@ -623,14 +621,15 @@
 			clock-names = "can_clk\0pclk";
 			reg = <0x00 0xff070000 0x00 0x1000>;
 			interrupts = <0x00 0x18 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
-			power-domains = <0x0c 0x30>;
-			clocks = <0x03 0x40 0x03 0x1f>;
+			resets = <0x11 0x29>;
+			power-domains = <0x12 0x30>;
+			clocks = <0x04 0x40 0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x0d>;
-			phandle = <0x63>;
+			pinctrl-0 = <0x13>;
+			phandle = <0x5a>;
 		};
 
 		cci@fd6e0000 {
@@ -640,12 +639,12 @@
 			ranges = <0x00 0x00 0xfd6e0000 0x10000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
-			phandle = <0x64>;
+			phandle = <0x5b>;
 
 			pmu@9000 {
 				compatible = "arm,cci-400-pmu,r1";
 				reg = <0x9000 0x5000>;
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupts = <0x00 0x7b 0x04 0x00 0x7b 0x04 0x00 0x7b 0x04 0x00 0x7b 0x04 0x00 0x7b 0x04>;
 			};
 		};
@@ -654,128 +653,120 @@
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd500000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7c 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14e8>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x65>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14e8>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5c>;
 		};
 
 		dma-controller@fd510000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd510000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7d 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14e9>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x66>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14e9>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5d>;
 		};
 
 		dma-controller@fd520000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd520000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7e 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ea>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x67>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ea>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5e>;
 		};
 
 		dma-controller@fd530000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd530000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7f 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14eb>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x68>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14eb>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5f>;
 		};
 
 		dma-controller@fd540000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd540000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x80 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ec>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x69>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ec>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x60>;
 		};
 
 		dma-controller@fd550000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd550000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x81 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ed>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6a>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ed>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x61>;
 		};
 
 		dma-controller@fd560000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd560000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x82 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ee>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6b>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ee>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x62>;
 		};
 
 		dma-controller@fd570000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd570000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x83 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ef>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6c>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ef>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x63>;
 		};
 
 		interrupt-controller@f9010000 {
@@ -783,153 +774,144 @@
 			#interrupt-cells = <0x03>;
 			reg = <0x00 0xf9010000 0x00 0x10000 0x00 0xf9020000 0x00 0x20000 0x00 0xf9040000 0x00 0x20000 0x00 0xf9060000 0x00 0x20000>;
 			interrupt-controller;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x01 0x09 0xf04>;
 			num_cpus = <0x02>;
 			num_interrupts = <0x60>;
-			phandle = <0x04>;
+			phandle = <0x05>;
 		};
 
 		gpu@fd4b0000 {
 			status = "okay";
-			compatible = "arm,mali-400\0arm,mali-utgard";
+			compatible = "xlnx,zynqmp-mali\0arm,mali-400";
 			reg = <0x00 0xfd4b0000 0x00 0x10000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04>;
-			interrupt-names = "IRQGP\0IRQGPMMU\0IRQPP0\0IRQPPMMU0\0IRQPP1\0IRQPPMMU1";
-			clock-names = "gpu\0gpu_pp0\0gpu_pp1";
-			power-domains = <0x0c 0x3a>;
-			clocks = <0x03 0x18 0x03 0x19 0x03 0x1a>;
+			interrupt-names = "gp\0gpmmu\0pp0\0ppmmu0\0pp1\0ppmmu1";
+			clock-names = "bus\0core";
+			power-domains = <0x12 0x3a>;
+			clocks = <0x04 0x18 0x04 0x19>;
 			xlnx,tz-nonsecure = <0x01>;
-			phandle = <0x6d>;
+			phandle = <0x64>;
 		};
 
 		dma-controller@ffa80000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffa80000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x4d 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x6e>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x65>;
 		};
 
 		dma-controller@ffa90000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffa90000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x4e 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x6f>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x66>;
 		};
 
 		dma-controller@ffaa0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffaa0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x4f 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x70>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x67>;
 		};
 
 		dma-controller@ffab0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffab0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x50 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x71>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x68>;
 		};
 
 		dma-controller@ffac0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffac0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x51 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x72>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x69>;
 		};
 
 		dma-controller@ffad0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffad0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x52 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x73>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x6a>;
 		};
 
 		dma-controller@ffae0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffae0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x53 0x04>;
 			clock-names = "clk_main\0clk_apb";
 			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
-			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x74>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x6b>;
 		};
 
 		dma-controller@ffaf0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffaf0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x54 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x75>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x6c>;
 		};
 
 		memory-controller@fd070000 {
 			compatible = "xlnx,zynqmp-ddrc-2.40a";
 			reg = <0x00 0xfd070000 0x00 0x30000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x70 0x04>;
-			phandle = <0x76>;
+			phandle = <0x6d>;
 		};
 
 		nand-controller@ff100000 {
@@ -937,96 +919,109 @@
 			status = "disabled";
 			reg = <0x00 0xff100000 0x00 0x1000>;
 			clock-names = "controller\0bus";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x0e 0x04>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x872>;
-			power-domains = <0x0c 0x2c>;
-			clocks = <0x03 0x3c 0x03 0x1f>;
-			phandle = <0x77>;
+			iommus = <0x14 0x872>;
+			power-domains = <0x12 0x2c>;
+			clocks = <0x04 0x3c 0x04 0x1f>;
+			phandle = <0x6e>;
 		};
 
 		ethernet@ff0b0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x39 0x04 0x00 0x39 0x04>;
 			reg = <0x00 0xff0b0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x874>;
-			power-domains = <0x0c 0x1d>;
-			resets = <0x0f 0x1d>;
-			clocks = <0x03 0x1f 0x03 0x68 0x03 0x2d 0x03 0x31 0x03 0x2c>;
-			phandle = <0x78>;
+			iommus = <0x14 0x874>;
+			power-domains = <0x12 0x1d>;
+			resets = <0x11 0x1d>;
+			reset-names = "gem0_rst";
+			clocks = <0x04 0x1f 0x04 0x68 0x04 0x2d 0x04 0x31 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phandle = <0x6f>;
 		};
 
 		ethernet@ff0c0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x3b 0x04 0x00 0x3b 0x04>;
 			reg = <0x00 0xff0c0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x875>;
-			power-domains = <0x0c 0x1e>;
-			resets = <0x0f 0x1e>;
-			clocks = <0x03 0x1f 0x03 0x69 0x03 0x2e 0x03 0x32 0x03 0x2c>;
-			phandle = <0x79>;
+			iommus = <0x14 0x875>;
+			power-domains = <0x12 0x1e>;
+			resets = <0x11 0x1e>;
+			reset-names = "gem1_rst";
+			clocks = <0x04 0x1f 0x04 0x69 0x04 0x2e 0x04 0x32 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phandle = <0x70>;
 		};
 
 		ethernet@ff0d0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x3d 0x04 0x00 0x3d 0x04>;
 			reg = <0x00 0xff0d0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x876>;
-			power-domains = <0x0c 0x1f>;
-			resets = <0x0f 0x1f>;
-			clocks = <0x03 0x1f 0x03 0x6a 0x03 0x2f 0x03 0x33 0x03 0x2c>;
-			phandle = <0x7a>;
+			iommus = <0x14 0x876>;
+			power-domains = <0x12 0x1f>;
+			resets = <0x11 0x1f>;
+			reset-names = "gem2_rst";
+			clocks = <0x04 0x1f 0x04 0x6a 0x04 0x2f 0x04 0x33 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phandle = <0x71>;
 		};
 
 		ethernet@ff0e0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x3f 0x04 0x00 0x3f 0x04>;
 			reg = <0x00 0xff0e0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x877>;
-			power-domains = <0x0c 0x20>;
-			resets = <0x0f 0x20>;
-			clocks = <0x03 0x1f 0x03 0x6b 0x03 0x30 0x03 0x34 0x03 0x2c>;
-			phy-handle = <0x10>;
+			iommus = <0x14 0x877>;
+			power-domains = <0x12 0x20>;
+			resets = <0x11 0x20>;
+			reset-names = "gem3_rst";
+			clocks = <0x04 0x1f 0x04 0x6b 0x04 0x30 0x04 0x34 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phy-handle = <0x15>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x11>;
+			pinctrl-0 = <0x16>;
 			phy-mode = "rgmii-id";
 			xlnx,ptp-enet-clock = <0x00>;
-			phandle = <0x7b>;
+			local-mac-address = [ff ff ff ff ff ff];
+			phandle = <0x72>;
 
-			ethernet-phy@c {
-				reg = <0x0c>;
-				ti,rx-internal-delay = <0x08>;
-				ti,tx-internal-delay = <0x0a>;
-				ti,fifo-depth = <0x01>;
-				ti,dp83867-rxctrl-strap-quirk;
-				phandle = <0x10>;
+			mdio {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				phandle = <0x73>;
+
+				ethernet-phy@c {
+					#phy-cells = <0x01>;
+					compatible = "ethernet-phy-id2000.a231";
+					reg = <0x0c>;
+					ti,rx-internal-delay = <0x08>;
+					ti,tx-internal-delay = <0x0a>;
+					ti,fifo-depth = <0x01>;
+					ti,dp83867-rxctrl-strap-quirk;
+					reset-gpios = <0x17 0x06 0x01>;
+					phandle = <0x15>;
+				};
 			};
 		};
 
@@ -1035,38 +1030,38 @@
 			status = "okay";
 			#gpio-cells = <0x02>;
 			gpio-controller;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x10 0x04>;
 			interrupt-controller;
 			#interrupt-cells = <0x02>;
 			reg = <0x00 0xff0a0000 0x00 0x1000>;
-			power-domains = <0x0c 0x2e>;
-			clocks = <0x03 0x1f>;
+			power-domains = <0x12 0x2e>;
+			clocks = <0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x12>;
+			pinctrl-0 = <0x18>;
 			emio-gpio-width = <0x20>;
 			gpio-mask-high = <0x00>;
 			gpio-mask-low = <0x5600>;
-			phandle = <0x15>;
+			phandle = <0x1b>;
 		};
 
 		i2c@ff020000 {
 			compatible = "cdns,i2c-r1p14";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x11 0x04>;
+			clock-frequency = <0x61a80>;
 			reg = <0x00 0xff020000 0x00 0x1000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x25>;
-			clocks = <0x03 0x3d>;
+			power-domains = <0x12 0x25>;
+			clocks = <0x04 0x3d>;
 			pinctrl-names = "default\0gpio";
-			pinctrl-0 = <0x13>;
-			pinctrl-1 = <0x14>;
-			scl-gpios = <0x15 0x0e 0x00>;
-			sda-gpios = <0x15 0x0f 0x00>;
-			clock-frequency = <0x61a80>;
-			phandle = <0x7c>;
+			pinctrl-0 = <0x19>;
+			pinctrl-1 = <0x1a>;
+			scl-gpios = <0x1b 0x0e 0x06>;
+			sda-gpios = <0x1b 0x0f 0x06>;
+			phandle = <0x74>;
 
 			gpio@20 {
 				compatible = "ti,tca6416";
@@ -1074,7 +1069,7 @@
 				gpio-controller;
 				#gpio-cells = <0x02>;
 				gpio-line-names = "PS_GTR_LAN_SEL0\0PS_GTR_LAN_SEL1\0PS_GTR_LAN_SEL2\0PS_GTR_LAN_SEL3\0PCI_CLK_DIR_SEL\0IIC_MUX_RESET_B\0GEM3_EXP_RESET_B\0\0\0\0\0\0\0\0\0";
-				phandle = <0x7d>;
+				phandle = <0x17>;
 			};
 
 			gpio@21 {
@@ -1083,7 +1078,7 @@
 				gpio-controller;
 				#gpio-cells = <0x02>;
 				gpio-line-names = "VCCPSPLL_EN\0MGTRAVCC_EN\0MGTRAVTT_EN\0VCCPSDDRPLL_EN\0MIO26_PMU_INPUT_LS\0PL_PMBUS_ALERT\0PS_PMBUS_ALERT\0MAXIM_PMBUS_ALERT\0PL_DDR4_VTERM_EN\0PL_DDR4_VPP_2V5_EN\0PS_DIMM_VDDQ_TO_PSVCCO_ON\0PS_DIMM_SUSPEND_EN\0PS_DDR4_VTERM_EN\0PS_DDR4_VPP_2V5_EN\0\0";
-				phandle = <0x7e>;
+				phandle = <0x75>;
 			};
 
 			i2c-mux@75 {
@@ -1103,7 +1098,7 @@
 						label = "ina226-u76";
 						reg = <0x40>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x29>;
+						phandle = <0x2e>;
 					};
 
 					ina226@41 {
@@ -1112,7 +1107,7 @@
 						label = "ina226-u77";
 						reg = <0x41>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2a>;
+						phandle = <0x2f>;
 					};
 
 					ina226@42 {
@@ -1121,7 +1116,7 @@
 						label = "ina226-u78";
 						reg = <0x42>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2b>;
+						phandle = <0x30>;
 					};
 
 					ina226@43 {
@@ -1130,7 +1125,7 @@
 						label = "ina226-u87";
 						reg = <0x43>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2c>;
+						phandle = <0x31>;
 					};
 
 					ina226@44 {
@@ -1139,7 +1134,7 @@
 						label = "ina226-u85";
 						reg = <0x44>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2d>;
+						phandle = <0x32>;
 					};
 
 					ina226@45 {
@@ -1148,7 +1143,7 @@
 						label = "ina226-u86";
 						reg = <0x45>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2e>;
+						phandle = <0x33>;
 					};
 
 					ina226@46 {
@@ -1157,7 +1152,7 @@
 						label = "ina226-u93";
 						reg = <0x46>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2f>;
+						phandle = <0x34>;
 					};
 
 					ina226@47 {
@@ -1166,7 +1161,7 @@
 						label = "ina226-u88";
 						reg = <0x47>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x30>;
+						phandle = <0x35>;
 					};
 
 					ina226@4a {
@@ -1175,7 +1170,7 @@
 						label = "ina226-u15";
 						reg = <0x4a>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x31>;
+						phandle = <0x36>;
 					};
 
 					ina226@4b {
@@ -1184,7 +1179,7 @@
 						label = "ina226-u92";
 						reg = <0x4b>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x32>;
+						phandle = <0x37>;
 					};
 				};
 
@@ -1199,7 +1194,7 @@
 						label = "ina226-u79";
 						reg = <0x40>;
 						shunt-resistor = <0x7d0>;
-						phandle = <0x33>;
+						phandle = <0x38>;
 					};
 
 					ina226@41 {
@@ -1208,7 +1203,7 @@
 						label = "ina226-u81";
 						reg = <0x41>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x34>;
+						phandle = <0x39>;
 					};
 
 					ina226@42 {
@@ -1217,7 +1212,7 @@
 						label = "ina226-u80";
 						reg = <0x42>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x35>;
+						phandle = <0x3a>;
 					};
 
 					ina226@43 {
@@ -1226,7 +1221,7 @@
 						label = "ina226-u84";
 						reg = <0x43>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x36>;
+						phandle = <0x3b>;
 					};
 
 					ina226@44 {
@@ -1235,7 +1230,7 @@
 						label = "ina226-u16";
 						reg = <0x44>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x37>;
+						phandle = <0x3c>;
 					};
 
 					ina226@45 {
@@ -1244,7 +1239,7 @@
 						label = "ina226-u65";
 						reg = <0x45>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x38>;
+						phandle = <0x3d>;
 					};
 
 					ina226@46 {
@@ -1253,7 +1248,7 @@
 						label = "ina226-u74";
 						reg = <0x46>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x39>;
+						phandle = <0x3e>;
 					};
 
 					ina226@47 {
@@ -1262,7 +1257,7 @@
 						label = "ina226-u75";
 						reg = <0x47>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x3a>;
+						phandle = <0x3f>;
 					};
 				};
 
@@ -1321,11 +1316,6 @@
 						reg = <0x1a>;
 					};
 
-					max15303@1b {
-						compatible = "maxim,max15303";
-						reg = <0x1b>;
-					};
-
 					max15303@1d {
 						compatible = "maxim,max15303";
 						reg = <0x1d>;
@@ -1340,6 +1330,11 @@
 						compatible = "maxim,max20751";
 						reg = <0x73>;
 					};
+
+					max15303@1b {
+						compatible = "maxim,max15303";
+						reg = <0x1b>;
+					};
 				};
 			};
 		};
@@ -1347,20 +1342,20 @@
 		i2c@ff030000 {
 			compatible = "cdns,i2c-r1p14";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x12 0x04>;
+			clock-frequency = <0x61a80>;
 			reg = <0x00 0xff030000 0x00 0x1000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x26>;
-			clocks = <0x03 0x3e>;
+			power-domains = <0x12 0x26>;
+			clocks = <0x04 0x3e>;
 			pinctrl-names = "default\0gpio";
-			pinctrl-0 = <0x16>;
-			pinctrl-1 = <0x17>;
-			scl-gpios = <0x15 0x10 0x00>;
-			sda-gpios = <0x15 0x11 0x00>;
-			clock-frequency = <0x61a80>;
-			phandle = <0x7f>;
+			pinctrl-0 = <0x1c>;
+			pinctrl-1 = <0x1d>;
+			scl-gpios = <0x1b 0x10 0x06>;
+			sda-gpios = <0x1b 0x11 0x06>;
+			phandle = <0x76>;
 
 			i2c-mux@74 {
 				compatible = "nxp,pca9548";
@@ -1378,26 +1373,26 @@
 						reg = <0x54>;
 						#address-cells = <0x01>;
 						#size-cells = <0x01>;
-						phandle = <0x80>;
+						phandle = <0x77>;
 
 						board-sn@0 {
 							reg = <0x00 0x14>;
-							phandle = <0x81>;
+							phandle = <0x78>;
 						};
 
 						eth-mac@20 {
 							reg = <0x20 0x06>;
-							phandle = <0x82>;
+							phandle = <0x79>;
 						};
 
 						board-name@d0 {
 							reg = <0xd0 0x06>;
-							phandle = <0x83>;
+							phandle = <0x7a>;
 						};
 
 						board-revision@e0 {
 							reg = <0xe0 0x03>;
-							phandle = <0x84>;
+							phandle = <0x7b>;
 						};
 					};
 				};
@@ -1413,57 +1408,57 @@
 						#clock-cells = <0x02>;
 						#address-cells = <0x01>;
 						#size-cells = <0x00>;
-						clocks = <0x18>;
+						clocks = <0x1e>;
 						clock-names = "xtal";
 						clock-output-names = "si5341";
-						phandle = <0x1c>;
+						phandle = <0x22>;
 
 						out@0 {
 							reg = <0x00>;
 							always-on;
-							phandle = <0x85>;
+							phandle = <0x7c>;
 						};
 
 						out@2 {
 							reg = <0x02>;
 							always-on;
-							phandle = <0x86>;
+							phandle = <0x7d>;
 						};
 
 						out@3 {
 							reg = <0x03>;
 							always-on;
-							phandle = <0x87>;
+							phandle = <0x7e>;
 						};
 
 						out@4 {
 							reg = <0x04>;
 							always-on;
-							phandle = <0x88>;
+							phandle = <0x7f>;
 						};
 
 						out@5 {
 							reg = <0x05>;
 							always-on;
-							phandle = <0x89>;
+							phandle = <0x80>;
 						};
 
 						out@6 {
 							reg = <0x06>;
 							always-on;
-							phandle = <0x8a>;
+							phandle = <0x81>;
 						};
 
 						out@7 {
 							reg = <0x07>;
 							always-on;
-							phandle = <0x8b>;
+							phandle = <0x82>;
 						};
 
 						out@9 {
 							reg = <0x09>;
 							always-on;
-							phandle = <0x8c>;
+							phandle = <0x83>;
 						};
 					};
 				};
@@ -1481,7 +1476,7 @@
 						factory-fout = <0x11e1a300>;
 						clock-frequency = <0x11e1a300>;
 						clock-output-names = "si570_user";
-						phandle = <0x8d>;
+						phandle = <0x84>;
 					};
 				};
 
@@ -1498,7 +1493,7 @@
 						factory-fout = <0x9502f90>;
 						clock-frequency = <0x8d9ee20>;
 						clock-output-names = "si570_mgt";
-						phandle = <0x8e>;
+						phandle = <0x85>;
 					};
 				};
 
@@ -1513,15 +1508,15 @@
 						#address-cells = <0x01>;
 						#size-cells = <0x00>;
 						#clock-cells = <0x01>;
-						clocks = <0x19>;
+						clocks = <0x1f>;
 						clock-names = "xtal";
 						clock-output-names = "si5328";
-						phandle = <0x8f>;
+						phandle = <0x86>;
 
 						clk0@0 {
 							reg = <0x00>;
 							clock-frequency = <0x19bfcc0>;
-							phandle = <0x90>;
+							phandle = <0x87>;
 						};
 					};
 				};
@@ -1586,16 +1581,16 @@
 		memory-controller@ff960000 {
 			compatible = "xlnx,zynqmp-ocmc-1.0";
 			reg = <0x00 0xff960000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x0a 0x04>;
-			phandle = <0x91>;
+			phandle = <0x88>;
 		};
 
 		perf-monitor@ffa00000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xffa00000 0x00 0x10000>;
 			interrupts = <0x00 0x19 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x01>;
@@ -1607,15 +1602,15 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x92>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x89>;
 		};
 
 		perf-monitor@fd0b0000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xfd0b0000 0x00 0x10000>;
 			interrupts = <0x00 0x7b 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x06>;
@@ -1627,15 +1622,15 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1c>;
-			phandle = <0x93>;
+			clocks = <0x04 0x1c>;
+			phandle = <0x8a>;
 		};
 
 		perf-monitor@fd490000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xfd490000 0x00 0x10000>;
 			interrupts = <0x00 0x7b 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x01>;
@@ -1647,15 +1642,15 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1c>;
-			phandle = <0x94>;
+			clocks = <0x04 0x1c>;
+			phandle = <0x8b>;
 		};
 
 		perf-monitor@ffa10000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xffa10000 0x00 0x10000>;
 			interrupts = <0x00 0x19 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x01>;
@@ -1667,8 +1662,8 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x95>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x8c>;
 		};
 
 		pcie@fd0e0000 {
@@ -1679,20 +1674,19 @@
 			#interrupt-cells = <0x01>;
 			msi-controller;
 			device_type = "pci";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x76 0x04 0x00 0x75 0x04 0x00 0x74 0x04 0x00 0x73 0x04 0x00 0x72 0x04>;
 			interrupt-names = "misc\0dummy\0intx\0msi1\0msi0";
-			msi-parent = <0x1a>;
-			reg = <0x00 0xfd0e0000 0x00 0x1000 0x00 0xfd480000 0x00 0x1000 0x80 0x00 0x00 0x1000000>;
+			msi-parent = <0x20>;
+			reg = <0x00 0xfd0e0000 0x00 0x1000 0x00 0xfd480000 0x00 0x1000 0x80 0x00 0x00 0x10000000>;
 			reg-names = "breg\0pcireg\0cfg";
 			ranges = <0x2000000 0x00 0xe0000000 0x00 0xe0000000 0x00 0x10000000 0x43000000 0x06 0x00 0x06 0x00 0x02 0x00>;
 			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
 			bus-range = <0x00 0xff>;
-			interrupt-map = <0x00 0x00 0x00 0x01 0x1b 0x01 0x00 0x00 0x00 0x02 0x1b 0x02 0x00 0x00 0x00 0x03 0x1b 0x03 0x00 0x00 0x00 0x04 0x1b 0x04>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x4d0>;
-			power-domains = <0x0c 0x3b>;
-			clocks = <0x03 0x17>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x21 0x01 0x00 0x00 0x00 0x02 0x21 0x02 0x00 0x00 0x00 0x03 0x21 0x03 0x00 0x00 0x00 0x04 0x21 0x04>;
+			iommus = <0x14 0x4d0>;
+			power-domains = <0x12 0x3b>;
+			clocks = <0x04 0x17>;
 			xlnx,bar0-enable = <0x00>;
 			xlnx,bar1-enable = <0x00>;
 			xlnx,bar2-enable = <0x00>;
@@ -1701,13 +1695,13 @@
 			xlnx,bar5-enable = <0x00>;
 			xlnx,pcie-mode = "Root Port";
 			xlnx,tz-nonsecure = <0x00>;
-			phandle = <0x1a>;
+			phandle = <0x20>;
 
 			legacy-interrupt-controller {
 				interrupt-controller;
 				#address-cells = <0x00>;
 				#interrupt-cells = <0x01>;
-				phandle = <0x1b>;
+				phandle = <0x21>;
 			};
 		};
 
@@ -1717,47 +1711,43 @@
 			status = "okay";
 			clock-names = "ref_clk\0pclk";
 			interrupts = <0x00 0x0f 0x04>;
-			interrupt-parent = <0x04>;
-			num-cs = <0x01>;
+			interrupt-parent = <0x05>;
+			num-cs = <0x02>;
 			reg = <0x00 0xff0f0000 0x00 0x1000 0x00 0xc0000000 0x00 0x8000000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x873>;
-			power-domains = <0x0c 0x2d>;
-			clocks = <0x03 0x35 0x03 0x1f>;
+			iommus = <0x14 0x873>;
+			power-domains = <0x12 0x2d>;
+			clocks = <0x04 0x35 0x04 0x1f>;
 			is-dual = <0x01>;
 			spi-rx-bus-width = <0x04>;
 			spi-tx-bus-width = <0x04>;
-			phandle = <0x96>;
+			phandle = <0x8d>;
 
 			flash@0 {
 				compatible = "m25p80\0jedec,spi-nor";
 				#address-cells = <0x01>;
 				#size-cells = <0x01>;
-				reg = <0x00>;
+				reg = <0x00 0x01>;
+				parallel-memories = <0x00 0x4000000 0x00 0x4000000>;
 				spi-tx-bus-width = <0x04>;
 				spi-rx-bus-width = <0x04>;
 				spi-max-frequency = <0x66ff300>;
+				phandle = <0x8e>;
 
 				partition@0 {
-					label = "qspi-fsbl-uboot";
-					reg = <0x00 0x100000>;
+					label = "qspi-boot";
+					reg = <0x00 0x1e00000>;
 				};
 
-				partition@100000 {
-					label = "qspi-linux";
-					reg = <0x100000 0x500000>;
+				partition@1 {
+					label = "qspi-bootenv";
+					reg = <0x1e00000 0x40000>;
 				};
 
-				partition@600000 {
-					label = "qspi-device-tree";
-					reg = <0x600000 0x20000>;
-				};
-
-				partition@620000 {
-					label = "qspi-rootfs";
-					reg = <0x620000 0x5e0000>;
+				partition@2 {
+					label = "qspi-kernel";
+					reg = <0x1e40000 0x2400000>;
 				};
 			};
 		};
@@ -1768,32 +1758,31 @@
 			reg = <0x00 0xfd400000 0x00 0x40000 0x00 0xfd3d0000 0x00 0x1000>;
 			reg-names = "serdes\0siou";
 			#phy-cells = <0x04>;
-			clocks = <0x1c 0x00 0x05 0x1c 0x00 0x03 0x1c 0x00 0x02 0x1c 0x00 0x00>;
+			clocks = <0x22 0x00 0x05 0x22 0x00 0x03 0x22 0x00 0x02 0x22 0x00 0x00>;
 			clock-names = "ref0\0ref1\0ref2\0ref3";
-			phandle = <0x22>;
+			phandle = <0x23>;
 		};
 
 		rtc@ffa60000 {
 			compatible = "xlnx,zynqmp-rtc";
 			status = "okay";
 			reg = <0x00 0xffa60000 0x00 0x100>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x1a 0x04 0x00 0x1b 0x04>;
 			interrupt-names = "alarm\0sec";
 			calibration = <0x7fff>;
-			phandle = <0x97>;
+			phandle = <0x8f>;
 		};
 
 		ahci@fd0c0000 {
 			compatible = "ceva,ahci-1v84";
 			status = "okay";
 			reg = <0x00 0xfd0c0000 0x00 0x2000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x85 0x04>;
-			power-domains = <0x0c 0x1c>;
-			resets = <0x0f 0x10>;
-			#stream-id-cells = <0x04>;
-			clocks = <0x03 0x16>;
+			power-domains = <0x12 0x1c>;
+			resets = <0x11 0x10>;
+			clocks = <0x04 0x16>;
 			ceva,p0-cominit-params = <0x18401828>;
 			ceva,p0-comwake-params = <0x614080e>;
 			ceva,p0-burst-params = <0x13084a06>;
@@ -1802,54 +1791,52 @@
 			ceva,p1-comwake-params = <0x614080e>;
 			ceva,p1-burst-params = <0x13084a06>;
 			ceva,p1-retry-params = <0x96a43ffc>;
+			phy-names = "sata-phy";
+			phys = <0x23 0x03 0x01 0x01 0x01>;
 			xlnx,tz-nonsecure-sata0 = <0x00>;
 			xlnx,tz-nonsecure-sata1 = <0x00>;
-			phandle = <0x98>;
+			phandle = <0x90>;
 		};
 
 		mmc@ff160000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-8.9a\0arasan,sdhci-8.9a";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x30 0x04>;
 			reg = <0x00 0xff160000 0x00 0x1000>;
 			clock-names = "clk_xin\0clk_ahb";
-			xlnx,device_id = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x870>;
-			power-domains = <0x0c 0x27>;
+			iommus = <0x14 0x870>;
+			power-domains = <0x12 0x27>;
 			#clock-cells = <0x01>;
 			clock-output-names = "clk_out_sd0\0clk_in_sd0";
-			resets = <0x0f 0x26>;
-			clocks = <0x03 0x36 0x03 0x1f>;
-			assigned-clocks = <0x03 0x36>;
-			phandle = <0x99>;
+			resets = <0x11 0x26>;
+			clocks = <0x04 0x36 0x04 0x1f>;
+			assigned-clocks = <0x04 0x36>;
+			phandle = <0x91>;
 		};
 
 		mmc@ff170000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-8.9a\0arasan,sdhci-8.9a";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x31 0x04>;
 			reg = <0x00 0xff170000 0x00 0x1000>;
 			clock-names = "clk_xin\0clk_ahb";
-			xlnx,device_id = <0x01>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x871>;
-			power-domains = <0x0c 0x28>;
+			iommus = <0x14 0x871>;
+			power-domains = <0x12 0x28>;
 			#clock-cells = <0x01>;
 			clock-output-names = "clk_out_sd1\0clk_in_sd1";
-			resets = <0x0f 0x27>;
-			clocks = <0x03 0x37 0x03 0x1f>;
-			assigned-clocks = <0x03 0x37>;
-			pinctrl-names = "default";
-			pinctrl-0 = <0x1d>;
+			resets = <0x11 0x27>;
+			clocks = <0x04 0x37 0x04 0x1f>;
+			assigned-clocks = <0x04 0x37>;
 			no-1-8-v;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x24>;
 			clock-frequency = <0xb2cbcae>;
 			xlnx,mio-bank = <0x01>;
-			phandle = <0x9a>;
+			phandle = <0x92>;
 		};
 
 		smmu@fd800000 {
@@ -1858,250 +1845,246 @@
 			#iommu-cells = <0x01>;
 			status = "disabled";
 			#global-interrupts = <0x01>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04>;
-			phandle = <0x0e>;
+			phandle = <0x14>;
 		};
 
 		spi@ff040000 {
 			compatible = "cdns,spi-r1p6";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x13 0x04>;
 			reg = <0x00 0xff040000 0x00 0x1000>;
 			clock-names = "ref_clk\0pclk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x23>;
-			clocks = <0x03 0x3a 0x03 0x1f>;
-			phandle = <0x9b>;
+			power-domains = <0x12 0x23>;
+			clocks = <0x04 0x3a 0x04 0x1f>;
+			phandle = <0x93>;
 		};
 
 		spi@ff050000 {
 			compatible = "cdns,spi-r1p6";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x14 0x04>;
 			reg = <0x00 0xff050000 0x00 0x1000>;
 			clock-names = "ref_clk\0pclk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x24>;
-			clocks = <0x03 0x3b 0x03 0x1f>;
-			phandle = <0x9c>;
+			power-domains = <0x12 0x24>;
+			clocks = <0x04 0x3b 0x04 0x1f>;
+			phandle = <0x94>;
 		};
 
 		timer@ff110000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x24 0x04 0x00 0x25 0x04 0x00 0x26 0x04>;
 			reg = <0x00 0xff110000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x18>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x9d>;
+			power-domains = <0x12 0x18>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x95>;
 		};
 
 		timer@ff120000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x27 0x04 0x00 0x28 0x04 0x00 0x29 0x04>;
 			reg = <0x00 0xff120000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x19>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x9e>;
+			power-domains = <0x12 0x19>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x96>;
 		};
 
 		timer@ff130000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x2a 0x04 0x00 0x2b 0x04 0x00 0x2c 0x04>;
 			reg = <0x00 0xff130000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x1a>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x9f>;
+			power-domains = <0x12 0x1a>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x97>;
 		};
 
 		timer@ff140000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x2d 0x04 0x00 0x2e 0x04 0x00 0x2f 0x04>;
 			reg = <0x00 0xff140000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x1b>;
-			clocks = <0x03 0x1f>;
-			phandle = <0xa0>;
+			power-domains = <0x12 0x1b>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x98>;
 		};
 
 		serial@ff000000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-uart\0cdns,uart-r1p12";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x15 0x04>;
 			reg = <0x00 0xff000000 0x00 0x1000>;
 			clock-names = "uart_clk\0pclk";
-			power-domains = <0x0c 0x21>;
-			clocks = <0x03 0x38 0x03 0x1f>;
+			power-domains = <0x12 0x21>;
+			clocks = <0x04 0x38 0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x1e>;
+			pinctrl-0 = <0x25>;
 			cts-override;
 			device_type = "serial";
 			port-number = <0x00>;
-			phandle = <0xa1>;
+			phandle = <0x99>;
 		};
 
 		serial@ff010000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-uart\0cdns,uart-r1p12";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x16 0x04>;
 			reg = <0x00 0xff010000 0x00 0x1000>;
 			clock-names = "uart_clk\0pclk";
-			power-domains = <0x0c 0x22>;
-			clocks = <0x03 0x39 0x03 0x1f>;
+			power-domains = <0x12 0x22>;
+			clocks = <0x04 0x39 0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x1f>;
+			pinctrl-0 = <0x26>;
 			cts-override;
 			device_type = "serial";
 			port-number = <0x01>;
-			phandle = <0xa2>;
+			phandle = <0x9a>;
 		};
 
-		usb0@ff9d0000 {
+		usb@ff9d0000 {
 			#address-cells = <0x02>;
 			#size-cells = <0x02>;
 			status = "okay";
 			compatible = "xlnx,zynqmp-dwc3";
 			reg = <0x00 0xff9d0000 0x00 0x100>;
 			clock-names = "bus_clk\0ref_clk";
-			power-domains = <0x0c 0x16>;
-			resets = <0x0f 0x3b 0x0f 0x3d 0x0f 0x3f>;
+			power-domains = <0x12 0x16>;
+			resets = <0x11 0x3b 0x11 0x3d 0x11 0x3f>;
 			reset-names = "usb_crst\0usb_hibrst\0usb_apbrst";
-			reset-gpios = <0x20 0x01 0x01>;
+			reset-gpios = <0x27 0x01 0x01>;
 			ranges;
-			clocks = <0x03 0x20 0x03 0x22>;
-			assigned-clocks = <0x03 0x20 0x03 0x22>;
+			clocks = <0x04 0x20 0x04 0x22>;
+			assigned-clocks = <0x04 0x20 0x04 0x22>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x21>;
+			pinctrl-0 = <0x28>;
 			phy-names = "usb3-phy";
-			phys = <0x22 0x02 0x04 0x00 0x02>;
+			phys = <0x23 0x02 0x04 0x00 0x02>;
 			xlnx,tz-nonsecure = <0x01>;
 			xlnx,usb-polarity = <0x00>;
 			xlnx,usb-reset-mode = <0x00>;
-			phandle = <0xa3>;
+			phandle = <0x9b>;
 
 			usb@fe200000 {
 				compatible = "snps,dwc3";
 				status = "okay";
 				reg = <0x00 0xfe200000 0x00 0x40000>;
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupt-names = "dwc_usb3\0otg\0hiber";
 				interrupts = <0x00 0x41 0x04 0x00 0x45 0x04 0x00 0x4b 0x04>;
-				#stream-id-cells = <0x01>;
-				iommus = <0x0e 0x860>;
+				iommus = <0x14 0x860>;
 				snps,quirk-frame-length-adjustment = <0x20>;
-				snps,refclk_fladj;
-				snps,enable_guctl1_resume_quirk;
+				clock-names = "ref";
 				snps,enable_guctl1_ipd_quirk;
-				snps,xhci-stream-quirk;
+				snps,resume-hs-terminations;
+				clocks = <0x04 0x22>;
 				dr_mode = "host";
 				snps,usb3_lpm_capable;
 				maximum-speed = "super-speed";
-				phandle = <0xa4>;
+				phandle = <0x9c>;
 			};
 		};
 
-		usb1@ff9e0000 {
+		usb@ff9e0000 {
 			#address-cells = <0x02>;
 			#size-cells = <0x02>;
 			status = "disabled";
 			compatible = "xlnx,zynqmp-dwc3";
 			reg = <0x00 0xff9e0000 0x00 0x100>;
 			clock-names = "bus_clk\0ref_clk";
-			power-domains = <0x0c 0x17>;
-			resets = <0x0f 0x3c 0x0f 0x3e 0x0f 0x40>;
+			power-domains = <0x12 0x17>;
+			resets = <0x11 0x3c 0x11 0x3e 0x11 0x40>;
 			reset-names = "usb_crst\0usb_hibrst\0usb_apbrst";
 			ranges;
-			clocks = <0x03 0x21 0x03 0x22>;
-			assigned-clocks = <0x03 0x21 0x03 0x22>;
-			phandle = <0xa5>;
+			clocks = <0x04 0x21 0x04 0x22>;
+			assigned-clocks = <0x04 0x21 0x04 0x22>;
+			phandle = <0x9d>;
 
 			usb@fe300000 {
 				compatible = "snps,dwc3";
 				status = "disabled";
 				reg = <0x00 0xfe300000 0x00 0x40000>;
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupt-names = "dwc_usb3\0otg\0hiber";
 				interrupts = <0x00 0x46 0x04 0x00 0x4a 0x04 0x00 0x4c 0x04>;
-				#stream-id-cells = <0x01>;
-				iommus = <0x0e 0x861>;
+				iommus = <0x14 0x861>;
 				snps,quirk-frame-length-adjustment = <0x20>;
-				snps,refclk_fladj;
-				snps,enable_guctl1_resume_quirk;
+				clock-names = "ref";
 				snps,enable_guctl1_ipd_quirk;
-				snps,xhci-stream-quirk;
-				phandle = <0xa6>;
+				snps,resume-hs-terminations;
+				clocks = <0x04 0x22>;
+				phandle = <0x9e>;
 			};
 		};
 
 		watchdog@fd4d0000 {
 			compatible = "cdns,wdt-r1p2";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x71 0x01>;
 			reg = <0x00 0xfd4d0000 0x00 0x1000>;
 			timeout-sec = <0x3c>;
 			reset-on-timeout;
-			clocks = <0x03 0x4b>;
-			phandle = <0xa7>;
+			clocks = <0x04 0x4b>;
+			phandle = <0x9f>;
 		};
 
 		watchdog@ff150000 {
 			compatible = "cdns,wdt-r1p2";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x34 0x01>;
 			reg = <0x00 0xff150000 0x00 0x1000>;
 			timeout-sec = <0x0a>;
-			clocks = <0x03 0x70>;
-			phandle = <0xa8>;
+			clocks = <0x04 0x70>;
+			phandle = <0xa0>;
 		};
 
 		ams@ffa50000 {
 			compatible = "xlnx,zynqmp-ams";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x38 0x04>;
-			interrupt-names = "ams-irq";
 			reg = <0x00 0xffa50000 0x00 0x800>;
-			reg-names = "ams-base";
-			#address-cells = <0x02>;
-			#size-cells = <0x02>;
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
 			#io-channel-cells = <0x01>;
-			ranges;
-			clocks = <0x03 0x46>;
-			phandle = <0xa9>;
+			ranges = <0x00 0x00 0xffa50800 0x800>;
+			clocks = <0x04 0x46>;
+			phandle = <0xa1>;
 
-			ams_ps@ffa50800 {
+			ams-ps@0 {
 				compatible = "xlnx,zynqmp-ams-ps";
 				status = "okay";
-				reg = <0x00 0xffa50800 0x00 0x400>;
-				phandle = <0xaa>;
+				reg = <0x00 0x400>;
+				phandle = <0xa2>;
 			};
 
-			ams_pl@ffa50c00 {
+			ams-pl@400 {
 				compatible = "xlnx,zynqmp-ams-pl";
 				status = "okay";
-				reg = <0x00 0xffa50c00 0x00 0x400>;
-				phandle = <0xab>;
+				reg = <0x400 0x400>;
+				phandle = <0xa3>;
 			};
 		};
 
@@ -2110,22 +2093,21 @@
 			status = "okay";
 			reg = <0x00 0xfd4c0000 0x00 0x1000>;
 			interrupts = <0x00 0x7a 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			clock-names = "axi_clk";
-			power-domains = <0x0c 0x29>;
+			power-domains = <0x12 0x29>;
 			dma-channels = <0x06>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0xce4>;
+			iommus = <0x14 0xce4>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x14>;
-			assigned-clocks = <0x03 0x14>;
-			phandle = <0x24>;
+			clocks = <0x04 0x14>;
+			assigned-clocks = <0x04 0x14>;
+			phandle = <0x2a>;
 		};
 
-		dp_aud@fd4ac000 {
+		dp-aud@fd4ac000 {
 			compatible = "xlnx,zynqmp-dpaud-setting\0syscon";
 			reg = <0x00 0xfd4ac000 0x00 0x1000>;
-			phandle = <0x23>;
+			phandle = <0x29>;
 		};
 
 		display@fd4a0000 {
@@ -2134,56 +2116,55 @@
 			status = "okay";
 			reg = <0x00 0xfd4a0000 0x00 0x1000 0x00 0xfd4aa000 0x00 0x1000 0x00 0xfd4ab000 0x00 0x1000>;
 			reg-names = "dp\0blend\0av_buf";
-			xlnx,dpaud-reg = <0x23>;
+			xlnx,dpaud-reg = <0x29>;
 			interrupts = <0x00 0x77 0x04>;
-			interrupt-parent = <0x04>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0xce3>;
+			interrupt-parent = <0x05>;
+			iommus = <0x14 0xce3>;
 			clock-names = "dp_apb_clk\0dp_aud_clk\0dp_vtc_pixel_clk_in";
-			power-domains = <0x0c 0x29>;
-			resets = <0x0f 0x03>;
+			power-domains = <0x12 0x29>;
+			resets = <0x11 0x03>;
 			dma-names = "vid0\0vid1\0vid2\0gfx0";
-			dmas = <0x24 0x00 0x24 0x01 0x24 0x02 0x24 0x03>;
-			clocks = <0x25 0x03 0x11 0x03 0x10>;
-			assigned-clocks = <0x03 0x12 0x03 0x11 0x03 0x10>;
+			dmas = <0x2a 0x00 0x2a 0x01 0x2a 0x02 0x2a 0x03>;
+			clocks = <0x04 0x1c 0x04 0x11 0x04 0x10>;
+			assigned-clocks = <0x04 0x12 0x04 0x11 0x04 0x10>;
 			phy-names = "dp-phy0";
-			phys = <0x22 0x01 0x06 0x00 0x03>;
+			phys = <0x23 0x01 0x06 0x00 0x03>;
 			xlnx,max-lanes = <0x01>;
-			phandle = <0xac>;
+			phandle = <0xa4>;
 
 			i2c-bus {
 			};
 
-			zynqmp_dp_snd_codec0 {
+			zynqmp-dp-snd-codec0 {
 				compatible = "xlnx,dp-snd-codec";
 				clock-names = "aud_clk";
-				clocks = <0x03 0x11>;
+				clocks = <0x04 0x11>;
 				status = "okay";
-				phandle = <0x28>;
+				phandle = <0x2d>;
 			};
 
-			zynqmp_dp_snd_pcm0 {
+			zynqmp-dp-snd-pcm0 {
 				compatible = "xlnx,dp-snd-pcm0";
-				dmas = <0x24 0x04>;
+				dmas = <0x2a 0x04>;
 				dma-names = "tx";
 				status = "okay";
-				phandle = <0x26>;
+				phandle = <0x2b>;
 			};
 
-			zynqmp_dp_snd_pcm1 {
+			zynqmp-dp-snd-pcm1 {
 				compatible = "xlnx,dp-snd-pcm1";
-				dmas = <0x24 0x05>;
+				dmas = <0x2a 0x05>;
 				dma-names = "tx";
 				status = "okay";
-				phandle = <0x27>;
+				phandle = <0x2c>;
 			};
 
-			zynqmp_dp_snd_card {
+			zynqmp-dp-snd-card {
 				compatible = "xlnx,dp-snd-card";
-				xlnx,dp-snd-pcm = <0x26 0x27>;
-				xlnx,dp-snd-codec = <0x28>;
+				xlnx,dp-snd-pcm = <0x2b 0x2c>;
+				xlnx,dp-snd-codec = <0x2d>;
 				status = "okay";
-				phandle = <0xad>;
+				phandle = <0xa5>;
 			};
 		};
 	};
@@ -2191,29 +2172,29 @@
 	fclk0 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x47>;
-		phandle = <0xae>;
+		clocks = <0x04 0x47>;
+		phandle = <0xa6>;
 	};
 
 	fclk1 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x48>;
-		phandle = <0xaf>;
+		clocks = <0x04 0x48>;
+		phandle = <0xa7>;
 	};
 
 	fclk2 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x49>;
-		phandle = <0xb0>;
+		clocks = <0x04 0x49>;
+		phandle = <0xa8>;
 	};
 
 	fclk3 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x4a>;
-		phandle = <0xb1>;
+		clocks = <0x04 0x4a>;
+		phandle = <0xa9>;
 	};
 
 	pss_ref_clk {
@@ -2221,7 +2202,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x1fc9350>;
-		phandle = <0x06>;
+		phandle = <0x0b>;
 	};
 
 	video_clk {
@@ -2229,7 +2210,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x1fc9f08>;
-		phandle = <0x07>;
+		phandle = <0x0c>;
 	};
 
 	pss_alt_ref_clk {
@@ -2237,7 +2218,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x00>;
-		phandle = <0x08>;
+		phandle = <0x0d>;
 	};
 
 	gt_crx_ref_clk {
@@ -2245,7 +2226,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x66ff300>;
-		phandle = <0x0a>;
+		phandle = <0x0f>;
 	};
 
 	aux_ref_clk {
@@ -2253,26 +2234,30 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x19bfcc0>;
-		phandle = <0x09>;
+		phandle = <0x0e>;
 	};
 
-	dp_aclk {
-		compatible = "fixed-clock";
-		#clock-cells = <0x00>;
-		clock-frequency = <0x5f5e100>;
-		clock-accuracy = <0x64>;
-		phandle = <0x25>;
+	aliases {
+		ethernet0 = "/axi/ethernet@ff0e0000";
+		i2c0 = "/axi/i2c@ff020000";
+		i2c1 = "/axi/i2c@ff030000";
+		mmc0 = "/axi/mmc@ff170000";
+		nvmem0 = "/axi/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
+		rtc0 = "/axi/rtc@ffa60000";
+		serial0 = "/axi/serial@ff000000";
+		serial1 = "/axi/serial@ff010000";
+		serial2 = "/dcc";
+		spi0 = "/axi/spi@ff0f0000";
+		usb0 = "/axi/usb@ff9d0000";
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
-		#address-cells = <0x01>;
-		#size-cells = <0x00>;
 		autorepeat;
 
-		sw19 {
+		switch-19 {
 			label = "sw19";
-			gpios = <0x15 0x16 0x00>;
+			gpios = <0x1b 0x16 0x00>;
 			linux,code = <0x6c>;
 			wakeup-source;
 			autorepeat;
@@ -2284,119 +2269,113 @@
 
 		heartbeat-led {
 			label = "heartbeat";
-			gpios = <0x15 0x17 0x00>;
+			gpios = <0x1b 0x17 0x00>;
 			linux,default-trigger = "heartbeat";
 		};
 	};
 
-	chosen {
-		nvmem0 = "/axi/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
-		bootargs = "earlycon";
-		stdout-path = "serial0:115200n8";
-	};
-
 	ina226-u76 {
-		compatible = "iio-hwmon";
-		io-channels = <0x29 0x00 0x29 0x01 0x29 0x02 0x29 0x03>;
-	};
-
-	ina226-u77 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2a 0x00 0x2a 0x01 0x2a 0x02 0x2a 0x03>;
-	};
-
-	ina226-u78 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2b 0x00 0x2b 0x01 0x2b 0x02 0x2b 0x03>;
-	};
-
-	ina226-u87 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2c 0x00 0x2c 0x01 0x2c 0x02 0x2c 0x03>;
-	};
-
-	ina226-u85 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2d 0x00 0x2d 0x01 0x2d 0x02 0x2d 0x03>;
-	};
-
-	ina226-u86 {
 		compatible = "iio-hwmon";
 		io-channels = <0x2e 0x00 0x2e 0x01 0x2e 0x02 0x2e 0x03>;
 	};
 
-	ina226-u93 {
+	ina226-u77 {
 		compatible = "iio-hwmon";
 		io-channels = <0x2f 0x00 0x2f 0x01 0x2f 0x02 0x2f 0x03>;
 	};
 
-	ina226-u88 {
+	ina226-u78 {
 		compatible = "iio-hwmon";
 		io-channels = <0x30 0x00 0x30 0x01 0x30 0x02 0x30 0x03>;
 	};
 
-	ina226-u15 {
+	ina226-u87 {
 		compatible = "iio-hwmon";
 		io-channels = <0x31 0x00 0x31 0x01 0x31 0x02 0x31 0x03>;
 	};
 
-	ina226-u92 {
+	ina226-u85 {
 		compatible = "iio-hwmon";
 		io-channels = <0x32 0x00 0x32 0x01 0x32 0x02 0x32 0x03>;
 	};
 
-	ina226-u79 {
+	ina226-u86 {
 		compatible = "iio-hwmon";
 		io-channels = <0x33 0x00 0x33 0x01 0x33 0x02 0x33 0x03>;
 	};
 
-	ina226-u81 {
+	ina226-u93 {
 		compatible = "iio-hwmon";
 		io-channels = <0x34 0x00 0x34 0x01 0x34 0x02 0x34 0x03>;
 	};
 
-	ina226-u80 {
+	ina226-u88 {
 		compatible = "iio-hwmon";
 		io-channels = <0x35 0x00 0x35 0x01 0x35 0x02 0x35 0x03>;
 	};
 
-	ina226-u84 {
+	ina226-u15 {
 		compatible = "iio-hwmon";
 		io-channels = <0x36 0x00 0x36 0x01 0x36 0x02 0x36 0x03>;
 	};
 
-	ina226-u16 {
+	ina226-u92 {
 		compatible = "iio-hwmon";
 		io-channels = <0x37 0x00 0x37 0x01 0x37 0x02 0x37 0x03>;
 	};
 
-	ina226-u65 {
+	ina226-u79 {
 		compatible = "iio-hwmon";
 		io-channels = <0x38 0x00 0x38 0x01 0x38 0x02 0x38 0x03>;
 	};
 
-	ina226-u74 {
+	ina226-u81 {
 		compatible = "iio-hwmon";
 		io-channels = <0x39 0x00 0x39 0x01 0x39 0x02 0x39 0x03>;
 	};
 
-	ina226-u75 {
+	ina226-u80 {
 		compatible = "iio-hwmon";
 		io-channels = <0x3a 0x00 0x3a 0x01 0x3a 0x02 0x3a 0x03>;
+	};
+
+	ina226-u84 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3b 0x00 0x3b 0x01 0x3b 0x02 0x3b 0x03>;
+	};
+
+	ina226-u16 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3c 0x00 0x3c 0x01 0x3c 0x02 0x3c 0x03>;
+	};
+
+	ina226-u65 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3d 0x00 0x3d 0x01 0x3d 0x02 0x3d 0x03>;
+	};
+
+	ina226-u74 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3e 0x00 0x3e 0x01 0x3e 0x02 0x3e 0x03>;
+	};
+
+	ina226-u75 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3f 0x00 0x3f 0x01 0x3f 0x02 0x3f 0x03>;
 	};
 
 	ref48M {
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x2dc6c00>;
-		phandle = <0x18>;
+		phandle = <0x1e>;
 	};
 
 	refhdmi {
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x6cfd9c8>;
-		phandle = <0x19>;
+		phandle = <0x1f>;
 	};
 
 	amba_pl@0 {
@@ -2404,135 +2383,44 @@
 		#size-cells = <0x02>;
 		compatible = "simple-bus";
 		ranges;
-		phandle = <0xb2>;
+		phandle = <0xaa>;
 
 		interrupt-controller@80020000 {
 			#interrupt-cells = <0x02>;
 			clock-names = "s_axi_aclk";
-			clocks = <0x3b>;
+			clocks = <0x40>;
 			compatible = "xlnx,axi-intc-4.1\0xlnx,xps-intc-1.00.a";
 			interrupt-controller;
 			interrupt-names = "irq";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x59 0x04>;
 			reg = <0x00 0x80020000 0x00 0x1000>;
 			xlnx,kind-of-intr = <0x01>;
 			xlnx,num-intr-inputs = <0x20>;
-			phandle = <0x3c>;
+			phandle = <0x41>;
 		};
 
 		misc_clk_0 {
 			#clock-cells = <0x00>;
 			clock-frequency = <0x4784b74>;
 			compatible = "fixed-clock";
-			phandle = <0x3b>;
+			phandle = <0x40>;
 		};
 
 		zyxclmm_drm {
 			compatible = "xlnx,zocl";
-			interrupts-extended = <0x3c 0x00 0x04 0x3c 0x01 0x04 0x3c 0x02 0x04 0x3c 0x03 0x04 0x3c 0x04 0x04 0x3c 0x05 0x04 0x3c 0x06 0x04 0x3c 0x07 0x04 0x3c 0x08 0x04 0x3c 0x09 0x04 0x3c 0x0a 0x04 0x3c 0x0b 0x04 0x3c 0x0c 0x04 0x3c 0x0d 0x04 0x3c 0x0e 0x04 0x3c 0x0f 0x04 0x3c 0x10 0x04 0x3c 0x11 0x04 0x3c 0x12 0x04 0x3c 0x13 0x04 0x3c 0x14 0x04 0x3c 0x15 0x04 0x3c 0x16 0x04 0x3c 0x17 0x04 0x3c 0x18 0x04 0x3c 0x19 0x04 0x3c 0x1a 0x04 0x3c 0x1b 0x04 0x3c 0x1c 0x04 0x3c 0x1d 0x04 0x3c 0x1e 0x04 0x3c 0x1f 0x04>;
+			interrupts-extended = <0x41 0x00 0x04 0x41 0x01 0x04 0x41 0x02 0x04 0x41 0x03 0x04 0x41 0x04 0x04 0x41 0x05 0x04 0x41 0x06 0x04 0x41 0x07 0x04 0x41 0x08 0x04 0x41 0x09 0x04 0x41 0x0a 0x04 0x41 0x0b 0x04 0x41 0x0c 0x04 0x41 0x0d 0x04 0x41 0x0e 0x04 0x41 0x0f 0x04 0x41 0x10 0x04 0x41 0x11 0x04 0x41 0x12 0x04 0x41 0x13 0x04 0x41 0x14 0x04 0x41 0x15 0x04 0x41 0x16 0x04 0x41 0x17 0x04 0x41 0x18 0x04 0x41 0x19 0x04 0x41 0x1a 0x04 0x41 0x1b 0x04 0x41 0x1c 0x04 0x41 0x1d 0x04 0x41 0x1e 0x04 0x41 0x1f 0x04>;
 		};
 	};
 
-	aliases {
-		ethernet0 = "/axi/ethernet@ff0e0000";
-		i2c0 = "/axi/i2c@ff020000";
-		i2c1 = "/axi/i2c@ff030000";
-		serial0 = "/axi/serial@ff000000";
-		serial1 = "/axi/serial@ff010000";
-		spi0 = "/axi/spi@ff0f0000";
+	chosen {
+		bootargs = "earlycon console=ttyPS0,115200 clk_ignore_unused root=/dev/ram0 rw init_fatal_sh=1";
+		stdout-path = "serial0:115200n8";
 	};
 
-	memory {
+	memory@0 {
 		device_type = "memory";
 		reg = <0x00 0x00 0x00 0x7ff00000 0x08 0x00 0x00 0x80000000>;
-	};
-
-	reserved-memory {
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-
-		rpu0vdev0vring0@3ed40000 {
-			no-map;
-			reg = <0x00 0x3ed40000 0x00 0x4000>;
-			phandle = <0x3f>;
-		};
-
-		rpu0vdev0vring1@3ed44000 {
-			no-map;
-			reg = <0x00 0x3ed44000 0x00 0x4000>;
-			phandle = <0x42>;
-		};
-
-		rpu0vdev0buffer@3ed48000 {
-			no-map;
-			reg = <0x00 0x3ed48000 0x00 0x100000>;
-			phandle = <0x3e>;
-		};
-
-		rproc@3ed00000 {
-			no-map;
-			reg = <0x00 0x3ed00000 0x00 0x40000>;
-			phandle = <0x3d>;
-		};
-	};
-
-	tcm_0a@ffe00000 {
-		no-map;
-		reg = <0x00 0xffe00000 0x00 0x10000>;
-		phandle = <0x40>;
-		status = "okay";
-		compatible = "mmio-sram";
-		power-domain = <0x0c 0x0f>;
-	};
-
-	tcm_0b@ffe20000 {
-		no-map;
-		reg = <0x00 0xffe20000 0x00 0x10000>;
-		phandle = <0x41>;
-		status = "okay";
-		compatible = "mmio-sram";
-		power-domain = <0x0c 0x10>;
-	};
-
-	rf5ss@ff9a0000 {
-		compatible = "xlnx,zynqmp-r5-remoteproc";
-		xlnx,cluster-mode = <0x01>;
-		ranges;
-		reg = <0x00 0xff9a0000 0x00 0x10000>;
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-
-		r5f_0 {
-			compatible = "xilinx,r5f";
-			#address-cells = <0x02>;
-			#size-cells = <0x02>;
-			ranges;
-			sram = <0x40 0x41>;
-			memory-region = <0x3d 0x3e 0x3f 0x42>;
-			power-domain = <0x0c 0x07>;
-			mboxes = <0x43 0x00 0x43 0x01>;
-			mbox-names = "tx\0rx";
-		};
-	};
-
-	zynqmp_ipi1 {
-		compatible = "xlnx,zynqmp-ipi-mailbox";
-		interrupt-parent = <0x04>;
-		interrupts = <0x00 0x1d 0x04>;
-		xlnx,ipi-id = <0x07>;
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-
-		mailbox@ff990600 {
-			reg = <0x00 0xff990600 0x00 0x20 0x00 0xff990620 0x00 0x20 0x00 0xff9900c0 0x00 0x20 0x00 0xff9900e0 0x00 0x20>;
-			reg-names = "local_request_region\0local_response_region\0remote_request_region\0remote_response_region";
-			#mbox-cells = <0x01>;
-			xlnx,ipi-id = <0x01>;
-			phandle = <0x43>;
-		};
 	};
 
 	__symbols__ {
@@ -2540,32 +2428,32 @@
 		cpu1 = "/cpus/cpu@1";
 		cpu2 = "/cpus/cpu@2";
 		cpu3 = "/cpus/cpu@3";
+		L2 = "/cpus/l2-cache";
 		CPU_SLEEP_0 = "/cpus/idle-states/cpu-sleep-0";
-		cpu_opp_table = "/cpu-opp-table";
-		zynqmp_ipi = "/zynqmp_ipi";
-		ipi_mailbox_pmu1 = "/zynqmp_ipi/mailbox@ff990400";
+		cpu_opp_table = "/opp-table-cpu";
+		zynqmp_ipi = "/zynqmp-ipi";
+		ipi_mailbox_pmu1 = "/zynqmp-ipi/mailbox@ff9905c0";
 		dcc = "/dcc";
 		zynqmp_firmware = "/firmware/zynqmp-firmware";
 		zynqmp_power = "/firmware/zynqmp-firmware/zynqmp-power";
-		soc_revision = "/firmware/zynqmp-firmware/nvmem_firmware/soc_revision@0";
-		efuse_dna = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_dna@c";
-		efuse_usr0 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr0@20";
-		efuse_usr1 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr1@24";
-		efuse_usr2 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr2@28";
-		efuse_usr3 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr3@2c";
-		efuse_usr4 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr4@30";
-		efuse_usr5 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr5@34";
-		efuse_usr6 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr6@38";
-		efuse_usr7 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr7@3c";
-		efuse_miscusr = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_miscusr@40";
-		efuse_chash = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_chash@50";
-		efuse_pufmisc = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_pufmisc@54";
-		efuse_sec = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_sec@58";
-		efuse_spkid = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_spkid@5c";
-		efuse_ppk0hash = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_ppk0hash@a0";
-		efuse_ppk1hash = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_ppk1hash@d0";
+		soc_revision = "/firmware/zynqmp-firmware/nvmem-firmware/soc-revision@0";
+		efuse_dna = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-dna@c";
+		efuse_usr0 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr0@20";
+		efuse_usr1 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr1@24";
+		efuse_usr2 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr2@28";
+		efuse_usr3 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr3@2c";
+		efuse_usr4 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr4@30";
+		efuse_usr5 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr5@34";
+		efuse_usr6 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr6@38";
+		efuse_usr7 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr7@3c";
+		efuse_miscusr = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-miscusr@40";
+		efuse_chash = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-chash@50";
+		efuse_pufmisc = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-pufmisc@54";
+		efuse_sec = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-sec@58";
+		efuse_spkid = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-spkid@5c";
+		efuse_ppk0hash = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-ppk0hash@a0";
+		efuse_ppk1hash = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-ppk1hash@d0";
 		zynqmp_pcap = "/firmware/zynqmp-firmware/pcap";
-		xlnx_aes = "/firmware/zynqmp-firmware/zynqmp-aes";
 		zynqmp_reset = "/firmware/zynqmp-firmware/reset-controller";
 		pinctrl0 = "/firmware/zynqmp-firmware/pinctrl";
 		pinctrl_i2c0_default = "/firmware/zynqmp-firmware/pinctrl/i2c0-default";
@@ -2579,8 +2467,6 @@
 		pinctrl_can1_default = "/firmware/zynqmp-firmware/pinctrl/can1-default";
 		pinctrl_sdhci1_default = "/firmware/zynqmp-firmware/pinctrl/sdhci1-default";
 		pinctrl_gpio_default = "/firmware/zynqmp-firmware/pinctrl/gpio-default";
-		xlnx_keccak_384 = "/firmware/zynqmp-firmware/sha384";
-		xlnx_rsa = "/firmware/zynqmp-firmware/zynqmp-rsa";
 		modepin_gpio = "/firmware/zynqmp-firmware/gpio";
 		zynqmp_clk = "/firmware/zynqmp-firmware/clock-controller";
 		fpga_full = "/fpga-full";
@@ -2612,7 +2498,8 @@
 		gem1 = "/axi/ethernet@ff0c0000";
 		gem2 = "/axi/ethernet@ff0d0000";
 		gem3 = "/axi/ethernet@ff0e0000";
-		phyc = "/axi/ethernet@ff0e0000/ethernet-phy@c";
+		mdio = "/axi/ethernet@ff0e0000/mdio";
+		phyc = "/axi/ethernet@ff0e0000/mdio/ethernet-phy@c";
 		gpio = "/axi/gpio@ff0a0000";
 		i2c0 = "/axi/i2c@ff020000";
 		tca6416_u97 = "/axi/i2c@ff020000/gpio@20";
@@ -2662,6 +2549,7 @@
 		pcie = "/axi/pcie@fd0e0000";
 		pcie_intc = "/axi/pcie@fd0e0000/legacy-interrupt-controller";
 		qspi = "/axi/spi@ff0f0000";
+		flash0 = "/axi/spi@ff0f0000/flash@0";
 		psgtr = "/axi/phy@fd400000";
 		rtc = "/axi/rtc@ffa60000";
 		sata = "/axi/ahci@fd0c0000";
@@ -2676,22 +2564,22 @@
 		ttc3 = "/axi/timer@ff140000";
 		uart0 = "/axi/serial@ff000000";
 		uart1 = "/axi/serial@ff010000";
-		usb0 = "/axi/usb0@ff9d0000";
-		dwc3_0 = "/axi/usb0@ff9d0000/usb@fe200000";
-		usb1 = "/axi/usb1@ff9e0000";
-		dwc3_1 = "/axi/usb1@ff9e0000/usb@fe300000";
+		usb0 = "/axi/usb@ff9d0000";
+		dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
+		usb1 = "/axi/usb@ff9e0000";
+		dwc3_1 = "/axi/usb@ff9e0000/usb@fe300000";
 		watchdog0 = "/axi/watchdog@fd4d0000";
 		lpd_watchdog = "/axi/watchdog@ff150000";
 		xilinx_ams = "/axi/ams@ffa50000";
-		ams_ps = "/axi/ams@ffa50000/ams_ps@ffa50800";
-		ams_pl = "/axi/ams@ffa50000/ams_pl@ffa50c00";
+		ams_ps = "/axi/ams@ffa50000/ams-ps@0";
+		ams_pl = "/axi/ams@ffa50000/ams-pl@400";
 		zynqmp_dpdma = "/axi/dma-controller@fd4c0000";
-		zynqmp_dpaud_setting = "/axi/dp_aud@fd4ac000";
+		zynqmp_dpaud_setting = "/axi/dp-aud@fd4ac000";
 		zynqmp_dpsub = "/axi/display@fd4a0000";
-		zynqmp_dp_snd_codec0 = "/axi/display@fd4a0000/zynqmp_dp_snd_codec0";
-		zynqmp_dp_snd_pcm0 = "/axi/display@fd4a0000/zynqmp_dp_snd_pcm0";
-		zynqmp_dp_snd_pcm1 = "/axi/display@fd4a0000/zynqmp_dp_snd_pcm1";
-		zynqmp_dp_snd_card0 = "/axi/display@fd4a0000/zynqmp_dp_snd_card";
+		zynqmp_dp_snd_codec0 = "/axi/display@fd4a0000/zynqmp-dp-snd-codec0";
+		zynqmp_dp_snd_pcm0 = "/axi/display@fd4a0000/zynqmp-dp-snd-pcm0";
+		zynqmp_dp_snd_pcm1 = "/axi/display@fd4a0000/zynqmp-dp-snd-pcm1";
+		zynqmp_dp_snd_card0 = "/axi/display@fd4a0000/zynqmp-dp-snd-card";
 		fclk0 = "/fclk0";
 		fclk1 = "/fclk1";
 		fclk2 = "/fclk2";
@@ -2701,16 +2589,10 @@
 		pss_alt_ref_clk = "/pss_alt_ref_clk";
 		gt_crx_ref_clk = "/gt_crx_ref_clk";
 		aux_ref_clk = "/aux_ref_clk";
-		dp_aclk = "/dp_aclk";
 		ref48 = "/ref48M";
 		refhdmi = "/refhdmi";
 		amba_pl = "/amba_pl@0";
 		axi_intc_0 = "/amba_pl@0/interrupt-controller@80020000";
 		misc_clk_0 = "/amba_pl@0/misc_clk_0";
-		rpu0vdev0vring0 = "/reserved-memory/rpu0vdev0vring0@3ed40000";
-		rpu0vdev0vring1 = "/reserved-memory/rpu0vdev0vring1@3ed44000";
-		rpu0vdev0buffer = "/reserved-memory/rpu0vdev0buffer@3ed48000";
-		rproc_0_reserved = "/reserved-memory/rproc@3ed00000";
-		ipi_mailbox_rpu0 = "/zynqmp_ipi1/mailbox@ff990600";
 	};
 };

--- a/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-lockstep.dts
@@ -385,31 +385,6 @@
 					};
 				};
 
-				uart1-default {
-					phandle = <0x26>;
-
-					mux {
-						groups = "uart1_5_grp";
-						function = "uart1";
-					};
-
-					conf {
-						groups = "uart1_5_grp";
-						slew-rate = <0x01>;
-						power-source = <0x01>;
-					};
-
-					conf-rx {
-						pins = "MIO21";
-						bias-high-impedance;
-					};
-
-					conf-tx {
-						pins = "MIO20";
-						bias-disable;
-					};
-				};
-
 				usb0-default {
 					phandle = <0x28>;
 
@@ -1994,24 +1969,6 @@
 			phandle = <0x99>;
 		};
 
-		serial@ff010000 {
-			u-boot,dm-pre-reloc;
-			compatible = "xlnx,zynqmp-uart\0cdns,uart-r1p12";
-			status = "okay";
-			interrupt-parent = <0x05>;
-			interrupts = <0x00 0x16 0x04>;
-			reg = <0x00 0xff010000 0x00 0x1000>;
-			clock-names = "uart_clk\0pclk";
-			power-domains = <0x12 0x22>;
-			clocks = <0x04 0x39 0x04 0x1f>;
-			pinctrl-names = "default";
-			pinctrl-0 = <0x26>;
-			cts-override;
-			device_type = "serial";
-			port-number = <0x01>;
-			phandle = <0x9a>;
-		};
-
 		usb@ff9d0000 {
 			#address-cells = <0x02>;
 			#size-cells = <0x02>;
@@ -2295,7 +2252,6 @@
 		nvmem0 = "/axi/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
 		rtc0 = "/axi/rtc@ffa60000";
 		serial0 = "/axi/serial@ff000000";
-		serial1 = "/axi/serial@ff010000";
 		serial2 = "/dcc";
 		spi0 = "/axi/spi@ff0f0000";
 		usb0 = "/axi/usb@ff9d0000";
@@ -2559,7 +2515,6 @@
 		pinctrl_i2c1_default = "/firmware/zynqmp-firmware/pinctrl/i2c1-default";
 		pinctrl_i2c1_gpio = "/firmware/zynqmp-firmware/pinctrl/i2c1-gpio";
 		pinctrl_uart0_default = "/firmware/zynqmp-firmware/pinctrl/uart0-default";
-		pinctrl_uart1_default = "/firmware/zynqmp-firmware/pinctrl/uart1-default";
 		pinctrl_usb0_default = "/firmware/zynqmp-firmware/pinctrl/usb0-default";
 		pinctrl_gem3_default = "/firmware/zynqmp-firmware/pinctrl/gem3-default";
 		pinctrl_can1_default = "/firmware/zynqmp-firmware/pinctrl/can1-default";
@@ -2661,7 +2616,6 @@
 		ttc2 = "/axi/timer@ff130000";
 		ttc3 = "/axi/timer@ff140000";
 		uart0 = "/axi/serial@ff000000";
-		uart1 = "/axi/serial@ff010000";
 		usb0 = "/axi/usb@ff9d0000";
 		dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
 		usb1 = "/axi/usb@ff9e0000";

--- a/examples/linux/dts/xilinx/zcu102-openamp-split.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-split.dts
@@ -17,8 +17,9 @@
 			operating-points-v2 = <0x01>;
 			reg = <0x00>;
 			cpu-idle-states = <0x02>;
-			clocks = <0x03 0x0a>;
-			phandle = <0x4b>;
+			next-level-cache = <0x03>;
+			clocks = <0x04 0x0a>;
+			phandle = <0x06>;
 		};
 
 		cpu@1 {
@@ -28,7 +29,8 @@
 			reg = <0x01>;
 			operating-points-v2 = <0x01>;
 			cpu-idle-states = <0x02>;
-			phandle = <0x4c>;
+			next-level-cache = <0x03>;
+			phandle = <0x07>;
 		};
 
 		cpu@2 {
@@ -38,7 +40,8 @@
 			reg = <0x02>;
 			operating-points-v2 = <0x01>;
 			cpu-idle-states = <0x02>;
-			phandle = <0x4d>;
+			next-level-cache = <0x03>;
+			phandle = <0x08>;
 		};
 
 		cpu@3 {
@@ -48,7 +51,14 @@
 			reg = <0x03>;
 			operating-points-v2 = <0x01>;
 			cpu-idle-states = <0x02>;
-			phandle = <0x4e>;
+			next-level-cache = <0x03>;
+			phandle = <0x09>;
+		};
+
+		l2-cache {
+			compatible = "cache";
+			cache-level = <0x02>;
+			phandle = <0x03>;
 		};
 
 		idle-states {
@@ -66,7 +76,7 @@
 		};
 	};
 
-	cpu-opp-table {
+	opp-table-cpu {
 		compatible = "operating-points-v2";
 		opp-shared;
 		phandle = <0x01>;
@@ -96,24 +106,24 @@
 		};
 	};
 
-	zynqmp_ipi {
+	zynqmp-ipi {
 		u-boot,dm-pre-reloc;
 		compatible = "xlnx,zynqmp-ipi-mailbox";
-		interrupt-parent = <0x04>;
+		interrupt-parent = <0x05>;
 		interrupts = <0x00 0x23 0x04>;
 		xlnx,ipi-id = <0x00>;
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-		phandle = <0x4f>;
+		phandle = <0x42>;
 
-		mailbox@ff990400 {
+		mailbox@ff9905c0 {
 			u-boot,dm-pre-reloc;
 			reg = <0x00 0xff9905c0 0x00 0x20 0x00 0xff9905e0 0x00 0x20 0x00 0xff990e80 0x00 0x20 0x00 0xff990ea0 0x00 0x20>;
 			reg-names = "local_request_region\0local_response_region\0remote_request_region\0remote_response_region";
 			#mbox-cells = <0x01>;
 			xlnx,ipi-id = <0x04>;
-			phandle = <0x05>;
+			phandle = <0x0a>;
 		};
 	};
 
@@ -121,13 +131,14 @@
 		compatible = "arm,dcc";
 		status = "disabled";
 		u-boot,dm-pre-reloc;
-		phandle = <0x50>;
+		phandle = <0x43>;
 	};
 
 	pmu {
 		compatible = "arm,armv8-pmuv3";
-		interrupt-parent = <0x04>;
+		interrupt-parent = <0x05>;
 		interrupts = <0x00 0x8f 0x04 0x00 0x90 0x04 0x00 0x91 0x04 0x00 0x92 0x04>;
+		interrupt-affinity = <0x06 0x07 0x08 0x09>;
 	};
 
 	psci {
@@ -142,134 +153,127 @@
 			u-boot,dm-pre-reloc;
 			method = "smc";
 			#power-domain-cells = <0x01>;
-			phandle = <0x0c>;
+			phandle = <0x12>;
 
 			zynqmp-power {
 				u-boot,dm-pre-reloc;
 				compatible = "xlnx,zynqmp-power";
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupts = <0x00 0x23 0x04>;
-				mboxes = <0x05 0x00 0x05 0x01>;
+				mboxes = <0x0a 0x00 0x0a 0x01>;
 				mbox-names = "tx\0rx";
-				phandle = <0x51>;
+				phandle = <0x44>;
 			};
 
-			nvmem_firmware {
+			nvmem-firmware {
 				compatible = "xlnx,zynqmp-nvmem-fw";
 				#address-cells = <0x01>;
 				#size-cells = <0x01>;
 
-				soc_revision@0 {
+				soc-revision@0 {
 					reg = <0x00 0x04>;
+					phandle = <0x45>;
+				};
+
+				efuse-dna@c {
+					reg = <0x0c 0x0c>;
+					phandle = <0x46>;
+				};
+
+				efuse-usr0@20 {
+					reg = <0x20 0x04>;
+					phandle = <0x47>;
+				};
+
+				efuse-usr1@24 {
+					reg = <0x24 0x04>;
+					phandle = <0x48>;
+				};
+
+				efuse-usr2@28 {
+					reg = <0x28 0x04>;
+					phandle = <0x49>;
+				};
+
+				efuse-usr3@2c {
+					reg = <0x2c 0x04>;
+					phandle = <0x4a>;
+				};
+
+				efuse-usr4@30 {
+					reg = <0x30 0x04>;
+					phandle = <0x4b>;
+				};
+
+				efuse-usr5@34 {
+					reg = <0x34 0x04>;
+					phandle = <0x4c>;
+				};
+
+				efuse-usr6@38 {
+					reg = <0x38 0x04>;
+					phandle = <0x4d>;
+				};
+
+				efuse-usr7@3c {
+					reg = <0x3c 0x04>;
+					phandle = <0x4e>;
+				};
+
+				efuse-miscusr@40 {
+					reg = <0x40 0x04>;
+					phandle = <0x4f>;
+				};
+
+				efuse-chash@50 {
+					reg = <0x50 0x04>;
+					phandle = <0x50>;
+				};
+
+				efuse-pufmisc@54 {
+					reg = <0x54 0x04>;
+					phandle = <0x51>;
+				};
+
+				efuse-sec@58 {
+					reg = <0x58 0x04>;
 					phandle = <0x52>;
 				};
 
-				efuse_dna@c {
-					reg = <0x0c 0x0c>;
+				efuse-spkid@5c {
+					reg = <0x5c 0x04>;
 					phandle = <0x53>;
 				};
 
-				efuse_usr0@20 {
-					reg = <0x20 0x04>;
+				efuse-ppk0hash@a0 {
+					reg = <0xa0 0x30>;
 					phandle = <0x54>;
 				};
 
-				efuse_usr1@24 {
-					reg = <0x24 0x04>;
-					phandle = <0x55>;
-				};
-
-				efuse_usr2@28 {
-					reg = <0x28 0x04>;
-					phandle = <0x56>;
-				};
-
-				efuse_usr3@2c {
-					reg = <0x2c 0x04>;
-					phandle = <0x57>;
-				};
-
-				efuse_usr4@30 {
-					reg = <0x30 0x04>;
-					phandle = <0x58>;
-				};
-
-				efuse_usr5@34 {
-					reg = <0x34 0x04>;
-					phandle = <0x59>;
-				};
-
-				efuse_usr6@38 {
-					reg = <0x38 0x04>;
-					phandle = <0x5a>;
-				};
-
-				efuse_usr7@3c {
-					reg = <0x3c 0x04>;
-					phandle = <0x5b>;
-				};
-
-				efuse_miscusr@40 {
-					reg = <0x40 0x04>;
-					phandle = <0x5c>;
-				};
-
-				efuse_chash@50 {
-					reg = <0x50 0x04>;
-					phandle = <0x5d>;
-				};
-
-				efuse_pufmisc@54 {
-					reg = <0x54 0x04>;
-					phandle = <0x5e>;
-				};
-
-				efuse_sec@58 {
-					reg = <0x58 0x04>;
-					phandle = <0x5f>;
-				};
-
-				efuse_spkid@5c {
-					reg = <0x5c 0x04>;
-					phandle = <0x60>;
-				};
-
-				efuse_ppk0hash@a0 {
-					reg = <0xa0 0x30>;
-					phandle = <0x61>;
-				};
-
-				efuse_ppk1hash@d0 {
+				efuse-ppk1hash@d0 {
 					reg = <0xd0 0x30>;
-					phandle = <0x62>;
+					phandle = <0x55>;
 				};
 			};
 
 			pcap {
 				compatible = "xlnx,zynqmp-pcap-fpga";
-				clock-names = "ref_clk";
-				clocks = <0x03 0x29>;
-				phandle = <0x0b>;
-			};
-
-			zynqmp-aes {
-				compatible = "xlnx,zynqmp-aes";
-				phandle = <0x63>;
+				phandle = <0x10>;
 			};
 
 			reset-controller {
 				compatible = "xlnx,zynqmp-reset";
 				#reset-cells = <0x01>;
-				phandle = <0x0f>;
+				phandle = <0x11>;
 			};
 
 			pinctrl {
 				compatible = "xlnx,zynqmp-pinctrl";
 				status = "okay";
-				phandle = <0x64>;
+				phandle = <0x56>;
 
 				i2c0-default {
-					phandle = <0x13>;
+					phandle = <0x19>;
 
 					mux {
 						groups = "i2c0_3_grp";
@@ -285,7 +289,7 @@
 				};
 
 				i2c0-gpio {
-					phandle = <0x14>;
+					phandle = <0x1a>;
 
 					mux {
 						groups = "gpio0_14_grp\0gpio0_15_grp";
@@ -300,7 +304,7 @@
 				};
 
 				i2c1-default {
-					phandle = <0x16>;
+					phandle = <0x1c>;
 
 					mux {
 						groups = "i2c1_4_grp";
@@ -316,7 +320,7 @@
 				};
 
 				i2c1-gpio {
-					phandle = <0x17>;
+					phandle = <0x1d>;
 
 					mux {
 						groups = "gpio0_16_grp\0gpio0_17_grp";
@@ -331,7 +335,7 @@
 				};
 
 				uart0-default {
-					phandle = <0x1e>;
+					phandle = <0x25>;
 
 					mux {
 						groups = "uart0_4_grp";
@@ -356,7 +360,7 @@
 				};
 
 				uart1-default {
-					phandle = <0x1f>;
+					phandle = <0x26>;
 
 					mux {
 						groups = "uart1_5_grp";
@@ -381,7 +385,7 @@
 				};
 
 				usb0-default {
-					phandle = <0x21>;
+					phandle = <0x28>;
 
 					mux {
 						groups = "usb0_0_grp";
@@ -390,23 +394,26 @@
 
 					conf {
 						groups = "usb0_0_grp";
-						slew-rate = <0x01>;
 						power-source = <0x01>;
 					};
 
 					conf-rx {
 						pins = "MIO52\0MIO53\0MIO55";
 						bias-high-impedance;
+						drive-strength = <0x0c>;
+						slew-rate = <0x00>;
 					};
 
 					conf-tx {
 						pins = "MIO54\0MIO56\0MIO57\0MIO58\0MIO59\0MIO60\0MIO61\0MIO62\0MIO63";
 						bias-disable;
+						drive-strength = <0x04>;
+						slew-rate = <0x01>;
 					};
 				};
 
 				gem3-default {
-					phandle = <0x11>;
+					phandle = <0x16>;
 
 					mux {
 						function = "ethernet3";
@@ -445,7 +452,7 @@
 				};
 
 				can1-default {
-					phandle = <0x0d>;
+					phandle = <0x13>;
 
 					mux {
 						function = "can1";
@@ -470,7 +477,7 @@
 				};
 
 				sdhci1-default {
-					phandle = <0x1d>;
+					phandle = <0x24>;
 
 					mux {
 						groups = "sdio1_0_grp";
@@ -512,7 +519,7 @@
 				};
 
 				gpio-default {
-					phandle = <0x12>;
+					phandle = <0x18>;
 
 					mux-sw {
 						function = "gpio0";
@@ -548,37 +555,27 @@
 				};
 			};
 
-			sha384 {
-				compatible = "xlnx,zynqmp-keccak-384";
-				phandle = <0x65>;
-			};
-
-			zynqmp-rsa {
-				compatible = "xlnx,zynqmp-rsa";
-				phandle = <0x66>;
-			};
-
 			gpio {
 				compatible = "xlnx,zynqmp-gpio-modepin";
 				gpio-controller;
 				#gpio-cells = <0x02>;
-				phandle = <0x20>;
+				phandle = <0x27>;
 			};
 
 			clock-controller {
 				u-boot,dm-pre-reloc;
 				#clock-cells = <0x01>;
 				compatible = "xlnx,zynqmp-clk";
-				clocks = <0x06 0x07 0x08 0x09 0x0a>;
+				clocks = <0x0b 0x0c 0x0d 0x0e 0x0f>;
 				clock-names = "pss_ref_clk\0video_clk\0pss_alt_ref_clk\0aux_ref_clk\0gt_crx_ref_clk";
-				phandle = <0x03>;
+				phandle = <0x04>;
 			};
 		};
 	};
 
 	timer {
 		compatible = "arm,armv8-timer";
-		interrupt-parent = <0x04>;
+		interrupt-parent = <0x05>;
 		interrupts = <0x01 0x0d 0xf08 0x01 0x0e 0xf08 0x01 0x0b 0xf08 0x01 0x0a 0xf08>;
 	};
 
@@ -588,11 +585,11 @@
 
 	fpga-full {
 		compatible = "fpga-region";
-		fpga-mgr = <0x0b>;
+		fpga-mgr = <0x10>;
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-		phandle = <0x67>;
+		phandle = <0x57>;
 	};
 
 	axi {
@@ -601,7 +598,7 @@
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-		phandle = <0x68>;
+		phandle = <0x58>;
 
 		can@ff060000 {
 			compatible = "xlnx,zynq-can-1.0";
@@ -609,12 +606,13 @@
 			clock-names = "can_clk\0pclk";
 			reg = <0x00 0xff060000 0x00 0x1000>;
 			interrupts = <0x00 0x17 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
-			power-domains = <0x0c 0x2f>;
-			clocks = <0x03 0x3f 0x03 0x1f>;
-			phandle = <0x69>;
+			resets = <0x11 0x28>;
+			power-domains = <0x12 0x2f>;
+			clocks = <0x04 0x3f 0x04 0x1f>;
+			phandle = <0x59>;
 		};
 
 		can@ff070000 {
@@ -623,14 +621,15 @@
 			clock-names = "can_clk\0pclk";
 			reg = <0x00 0xff070000 0x00 0x1000>;
 			interrupts = <0x00 0x18 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
-			power-domains = <0x0c 0x30>;
-			clocks = <0x03 0x40 0x03 0x1f>;
+			resets = <0x11 0x29>;
+			power-domains = <0x12 0x30>;
+			clocks = <0x04 0x40 0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x0d>;
-			phandle = <0x6a>;
+			pinctrl-0 = <0x13>;
+			phandle = <0x5a>;
 		};
 
 		cci@fd6e0000 {
@@ -640,12 +639,12 @@
 			ranges = <0x00 0x00 0xfd6e0000 0x10000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
-			phandle = <0x6b>;
+			phandle = <0x5b>;
 
 			pmu@9000 {
 				compatible = "arm,cci-400-pmu,r1";
 				reg = <0x9000 0x5000>;
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupts = <0x00 0x7b 0x04 0x00 0x7b 0x04 0x00 0x7b 0x04 0x00 0x7b 0x04 0x00 0x7b 0x04>;
 			};
 		};
@@ -654,128 +653,120 @@
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd500000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7c 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14e8>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6c>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14e8>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5c>;
 		};
 
 		dma-controller@fd510000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd510000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7d 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14e9>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6d>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14e9>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5d>;
 		};
 
 		dma-controller@fd520000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd520000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7e 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ea>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6e>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ea>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5e>;
 		};
 
 		dma-controller@fd530000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd530000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x7f 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14eb>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x6f>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14eb>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x5f>;
 		};
 
 		dma-controller@fd540000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd540000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x80 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ec>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x70>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ec>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x60>;
 		};
 
 		dma-controller@fd550000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd550000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x81 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ed>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x71>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ed>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x61>;
 		};
 
 		dma-controller@fd560000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd560000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x82 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ee>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x72>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ee>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x62>;
 		};
 
 		dma-controller@fd570000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xfd570000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x83 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x80>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x14ef>;
-			power-domains = <0x0c 0x2a>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x13 0x03 0x1f>;
-			phandle = <0x73>;
+			xlnx,bus-width = <0x80>;
+			iommus = <0x14 0x14ef>;
+			power-domains = <0x12 0x2a>;
+			clocks = <0x04 0x13 0x04 0x1f>;
+			phandle = <0x63>;
 		};
 
 		interrupt-controller@f9010000 {
@@ -783,153 +774,144 @@
 			#interrupt-cells = <0x03>;
 			reg = <0x00 0xf9010000 0x00 0x10000 0x00 0xf9020000 0x00 0x20000 0x00 0xf9040000 0x00 0x20000 0x00 0xf9060000 0x00 0x20000>;
 			interrupt-controller;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x01 0x09 0xf04>;
 			num_cpus = <0x02>;
 			num_interrupts = <0x60>;
-			phandle = <0x04>;
+			phandle = <0x05>;
 		};
 
 		gpu@fd4b0000 {
 			status = "okay";
-			compatible = "arm,mali-400\0arm,mali-utgard";
+			compatible = "xlnx,zynqmp-mali\0arm,mali-400";
 			reg = <0x00 0xfd4b0000 0x00 0x10000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04 0x00 0x84 0x04>;
-			interrupt-names = "IRQGP\0IRQGPMMU\0IRQPP0\0IRQPPMMU0\0IRQPP1\0IRQPPMMU1";
-			clock-names = "gpu\0gpu_pp0\0gpu_pp1";
-			power-domains = <0x0c 0x3a>;
-			clocks = <0x03 0x18 0x03 0x19 0x03 0x1a>;
+			interrupt-names = "gp\0gpmmu\0pp0\0ppmmu0\0pp1\0ppmmu1";
+			clock-names = "bus\0core";
+			power-domains = <0x12 0x3a>;
+			clocks = <0x04 0x18 0x04 0x19>;
 			xlnx,tz-nonsecure = <0x01>;
-			phandle = <0x74>;
+			phandle = <0x64>;
 		};
 
 		dma-controller@ffa80000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffa80000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x4d 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x75>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x65>;
 		};
 
 		dma-controller@ffa90000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffa90000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x4e 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x76>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x66>;
 		};
 
 		dma-controller@ffaa0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffaa0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x4f 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x77>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x67>;
 		};
 
 		dma-controller@ffab0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffab0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x50 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x78>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x68>;
 		};
 
 		dma-controller@ffac0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffac0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x51 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x79>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x69>;
 		};
 
 		dma-controller@ffad0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffad0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x52 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x7a>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x6a>;
 		};
 
 		dma-controller@ffae0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffae0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x53 0x04>;
 			clock-names = "clk_main\0clk_apb";
 			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
-			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x7b>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x6b>;
 		};
 
 		dma-controller@ffaf0000 {
 			status = "okay";
 			compatible = "xlnx,zynqmp-dma-1.0";
 			reg = <0x00 0xffaf0000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x54 0x04>;
 			clock-names = "clk_main\0clk_apb";
-			xlnx,bus-width = <0x40>;
-			#stream-id-cells = <0x01>;
-			power-domains = <0x0c 0x2b>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x44 0x03 0x1f>;
-			phandle = <0x7c>;
+			xlnx,bus-width = <0x40>;
+			power-domains = <0x12 0x2b>;
+			clocks = <0x04 0x44 0x04 0x1f>;
+			phandle = <0x6c>;
 		};
 
 		memory-controller@fd070000 {
 			compatible = "xlnx,zynqmp-ddrc-2.40a";
 			reg = <0x00 0xfd070000 0x00 0x30000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x70 0x04>;
-			phandle = <0x7d>;
+			phandle = <0x6d>;
 		};
 
 		nand-controller@ff100000 {
@@ -937,96 +919,109 @@
 			status = "disabled";
 			reg = <0x00 0xff100000 0x00 0x1000>;
 			clock-names = "controller\0bus";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x0e 0x04>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x872>;
-			power-domains = <0x0c 0x2c>;
-			clocks = <0x03 0x3c 0x03 0x1f>;
-			phandle = <0x7e>;
+			iommus = <0x14 0x872>;
+			power-domains = <0x12 0x2c>;
+			clocks = <0x04 0x3c 0x04 0x1f>;
+			phandle = <0x6e>;
 		};
 
 		ethernet@ff0b0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x39 0x04 0x00 0x39 0x04>;
 			reg = <0x00 0xff0b0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x874>;
-			power-domains = <0x0c 0x1d>;
-			resets = <0x0f 0x1d>;
-			clocks = <0x03 0x1f 0x03 0x68 0x03 0x2d 0x03 0x31 0x03 0x2c>;
-			phandle = <0x7f>;
+			iommus = <0x14 0x874>;
+			power-domains = <0x12 0x1d>;
+			resets = <0x11 0x1d>;
+			reset-names = "gem0_rst";
+			clocks = <0x04 0x1f 0x04 0x68 0x04 0x2d 0x04 0x31 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phandle = <0x6f>;
 		};
 
 		ethernet@ff0c0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x3b 0x04 0x00 0x3b 0x04>;
 			reg = <0x00 0xff0c0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x875>;
-			power-domains = <0x0c 0x1e>;
-			resets = <0x0f 0x1e>;
-			clocks = <0x03 0x1f 0x03 0x69 0x03 0x2e 0x03 0x32 0x03 0x2c>;
-			phandle = <0x80>;
+			iommus = <0x14 0x875>;
+			power-domains = <0x12 0x1e>;
+			resets = <0x11 0x1e>;
+			reset-names = "gem1_rst";
+			clocks = <0x04 0x1f 0x04 0x69 0x04 0x2e 0x04 0x32 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phandle = <0x70>;
 		};
 
 		ethernet@ff0d0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x3d 0x04 0x00 0x3d 0x04>;
 			reg = <0x00 0xff0d0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x876>;
-			power-domains = <0x0c 0x1f>;
-			resets = <0x0f 0x1f>;
-			clocks = <0x03 0x1f 0x03 0x6a 0x03 0x2f 0x03 0x33 0x03 0x2c>;
-			phandle = <0x81>;
+			iommus = <0x14 0x876>;
+			power-domains = <0x12 0x1f>;
+			resets = <0x11 0x1f>;
+			reset-names = "gem2_rst";
+			clocks = <0x04 0x1f 0x04 0x6a 0x04 0x2f 0x04 0x33 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phandle = <0x71>;
 		};
 
 		ethernet@ff0e0000 {
-			compatible = "cdns,zynqmp-gem\0cdns,gem";
+			compatible = "xlnx,zynqmp-gem\0cdns,gem";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x3f 0x04 0x00 0x3f 0x04>;
 			reg = <0x00 0xff0e0000 0x00 0x1000>;
 			clock-names = "pclk\0hclk\0tx_clk\0rx_clk\0tsu_clk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x877>;
-			power-domains = <0x0c 0x20>;
-			resets = <0x0f 0x20>;
-			clocks = <0x03 0x1f 0x03 0x6b 0x03 0x30 0x03 0x34 0x03 0x2c>;
-			phy-handle = <0x10>;
+			iommus = <0x14 0x877>;
+			power-domains = <0x12 0x20>;
+			resets = <0x11 0x20>;
+			reset-names = "gem3_rst";
+			clocks = <0x04 0x1f 0x04 0x6b 0x04 0x30 0x04 0x34 0x04 0x2c>;
+			assigned-clocks = <0x04 0x2c>;
+			phy-handle = <0x15>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x11>;
+			pinctrl-0 = <0x16>;
 			phy-mode = "rgmii-id";
 			xlnx,ptp-enet-clock = <0x00>;
-			phandle = <0x82>;
+			local-mac-address = [ff ff ff ff ff ff];
+			phandle = <0x72>;
 
-			ethernet-phy@c {
-				reg = <0x0c>;
-				ti,rx-internal-delay = <0x08>;
-				ti,tx-internal-delay = <0x0a>;
-				ti,fifo-depth = <0x01>;
-				ti,dp83867-rxctrl-strap-quirk;
-				phandle = <0x10>;
+			mdio {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				phandle = <0x73>;
+
+				ethernet-phy@c {
+					#phy-cells = <0x01>;
+					compatible = "ethernet-phy-id2000.a231";
+					reg = <0x0c>;
+					ti,rx-internal-delay = <0x08>;
+					ti,tx-internal-delay = <0x0a>;
+					ti,fifo-depth = <0x01>;
+					ti,dp83867-rxctrl-strap-quirk;
+					reset-gpios = <0x17 0x06 0x01>;
+					phandle = <0x15>;
+				};
 			};
 		};
 
@@ -1035,38 +1030,38 @@
 			status = "okay";
 			#gpio-cells = <0x02>;
 			gpio-controller;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x10 0x04>;
 			interrupt-controller;
 			#interrupt-cells = <0x02>;
 			reg = <0x00 0xff0a0000 0x00 0x1000>;
-			power-domains = <0x0c 0x2e>;
-			clocks = <0x03 0x1f>;
+			power-domains = <0x12 0x2e>;
+			clocks = <0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x12>;
+			pinctrl-0 = <0x18>;
 			emio-gpio-width = <0x20>;
 			gpio-mask-high = <0x00>;
 			gpio-mask-low = <0x5600>;
-			phandle = <0x15>;
+			phandle = <0x1b>;
 		};
 
 		i2c@ff020000 {
 			compatible = "cdns,i2c-r1p14";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x11 0x04>;
+			clock-frequency = <0x61a80>;
 			reg = <0x00 0xff020000 0x00 0x1000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x25>;
-			clocks = <0x03 0x3d>;
+			power-domains = <0x12 0x25>;
+			clocks = <0x04 0x3d>;
 			pinctrl-names = "default\0gpio";
-			pinctrl-0 = <0x13>;
-			pinctrl-1 = <0x14>;
-			scl-gpios = <0x15 0x0e 0x00>;
-			sda-gpios = <0x15 0x0f 0x00>;
-			clock-frequency = <0x61a80>;
-			phandle = <0x83>;
+			pinctrl-0 = <0x19>;
+			pinctrl-1 = <0x1a>;
+			scl-gpios = <0x1b 0x0e 0x06>;
+			sda-gpios = <0x1b 0x0f 0x06>;
+			phandle = <0x74>;
 
 			gpio@20 {
 				compatible = "ti,tca6416";
@@ -1074,7 +1069,7 @@
 				gpio-controller;
 				#gpio-cells = <0x02>;
 				gpio-line-names = "PS_GTR_LAN_SEL0\0PS_GTR_LAN_SEL1\0PS_GTR_LAN_SEL2\0PS_GTR_LAN_SEL3\0PCI_CLK_DIR_SEL\0IIC_MUX_RESET_B\0GEM3_EXP_RESET_B\0\0\0\0\0\0\0\0\0";
-				phandle = <0x84>;
+				phandle = <0x17>;
 			};
 
 			gpio@21 {
@@ -1083,7 +1078,7 @@
 				gpio-controller;
 				#gpio-cells = <0x02>;
 				gpio-line-names = "VCCPSPLL_EN\0MGTRAVCC_EN\0MGTRAVTT_EN\0VCCPSDDRPLL_EN\0MIO26_PMU_INPUT_LS\0PL_PMBUS_ALERT\0PS_PMBUS_ALERT\0MAXIM_PMBUS_ALERT\0PL_DDR4_VTERM_EN\0PL_DDR4_VPP_2V5_EN\0PS_DIMM_VDDQ_TO_PSVCCO_ON\0PS_DIMM_SUSPEND_EN\0PS_DDR4_VTERM_EN\0PS_DDR4_VPP_2V5_EN\0\0";
-				phandle = <0x85>;
+				phandle = <0x75>;
 			};
 
 			i2c-mux@75 {
@@ -1103,7 +1098,7 @@
 						label = "ina226-u76";
 						reg = <0x40>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x29>;
+						phandle = <0x2e>;
 					};
 
 					ina226@41 {
@@ -1112,7 +1107,7 @@
 						label = "ina226-u77";
 						reg = <0x41>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2a>;
+						phandle = <0x2f>;
 					};
 
 					ina226@42 {
@@ -1121,7 +1116,7 @@
 						label = "ina226-u78";
 						reg = <0x42>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2b>;
+						phandle = <0x30>;
 					};
 
 					ina226@43 {
@@ -1130,7 +1125,7 @@
 						label = "ina226-u87";
 						reg = <0x43>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2c>;
+						phandle = <0x31>;
 					};
 
 					ina226@44 {
@@ -1139,7 +1134,7 @@
 						label = "ina226-u85";
 						reg = <0x44>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2d>;
+						phandle = <0x32>;
 					};
 
 					ina226@45 {
@@ -1148,7 +1143,7 @@
 						label = "ina226-u86";
 						reg = <0x45>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2e>;
+						phandle = <0x33>;
 					};
 
 					ina226@46 {
@@ -1157,7 +1152,7 @@
 						label = "ina226-u93";
 						reg = <0x46>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x2f>;
+						phandle = <0x34>;
 					};
 
 					ina226@47 {
@@ -1166,7 +1161,7 @@
 						label = "ina226-u88";
 						reg = <0x47>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x30>;
+						phandle = <0x35>;
 					};
 
 					ina226@4a {
@@ -1175,7 +1170,7 @@
 						label = "ina226-u15";
 						reg = <0x4a>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x31>;
+						phandle = <0x36>;
 					};
 
 					ina226@4b {
@@ -1184,7 +1179,7 @@
 						label = "ina226-u92";
 						reg = <0x4b>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x32>;
+						phandle = <0x37>;
 					};
 				};
 
@@ -1199,7 +1194,7 @@
 						label = "ina226-u79";
 						reg = <0x40>;
 						shunt-resistor = <0x7d0>;
-						phandle = <0x33>;
+						phandle = <0x38>;
 					};
 
 					ina226@41 {
@@ -1208,7 +1203,7 @@
 						label = "ina226-u81";
 						reg = <0x41>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x34>;
+						phandle = <0x39>;
 					};
 
 					ina226@42 {
@@ -1217,7 +1212,7 @@
 						label = "ina226-u80";
 						reg = <0x42>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x35>;
+						phandle = <0x3a>;
 					};
 
 					ina226@43 {
@@ -1226,7 +1221,7 @@
 						label = "ina226-u84";
 						reg = <0x43>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x36>;
+						phandle = <0x3b>;
 					};
 
 					ina226@44 {
@@ -1235,7 +1230,7 @@
 						label = "ina226-u16";
 						reg = <0x44>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x37>;
+						phandle = <0x3c>;
 					};
 
 					ina226@45 {
@@ -1244,7 +1239,7 @@
 						label = "ina226-u65";
 						reg = <0x45>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x38>;
+						phandle = <0x3d>;
 					};
 
 					ina226@46 {
@@ -1253,7 +1248,7 @@
 						label = "ina226-u74";
 						reg = <0x46>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x39>;
+						phandle = <0x3e>;
 					};
 
 					ina226@47 {
@@ -1262,7 +1257,7 @@
 						label = "ina226-u75";
 						reg = <0x47>;
 						shunt-resistor = <0x1388>;
-						phandle = <0x3a>;
+						phandle = <0x3f>;
 					};
 				};
 
@@ -1321,11 +1316,6 @@
 						reg = <0x1a>;
 					};
 
-					max15303@1b {
-						compatible = "maxim,max15303";
-						reg = <0x1b>;
-					};
-
 					max15303@1d {
 						compatible = "maxim,max15303";
 						reg = <0x1d>;
@@ -1340,6 +1330,11 @@
 						compatible = "maxim,max20751";
 						reg = <0x73>;
 					};
+
+					max15303@1b {
+						compatible = "maxim,max15303";
+						reg = <0x1b>;
+					};
 				};
 			};
 		};
@@ -1347,20 +1342,20 @@
 		i2c@ff030000 {
 			compatible = "cdns,i2c-r1p14";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x12 0x04>;
+			clock-frequency = <0x61a80>;
 			reg = <0x00 0xff030000 0x00 0x1000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x26>;
-			clocks = <0x03 0x3e>;
+			power-domains = <0x12 0x26>;
+			clocks = <0x04 0x3e>;
 			pinctrl-names = "default\0gpio";
-			pinctrl-0 = <0x16>;
-			pinctrl-1 = <0x17>;
-			scl-gpios = <0x15 0x10 0x00>;
-			sda-gpios = <0x15 0x11 0x00>;
-			clock-frequency = <0x61a80>;
-			phandle = <0x86>;
+			pinctrl-0 = <0x1c>;
+			pinctrl-1 = <0x1d>;
+			scl-gpios = <0x1b 0x10 0x06>;
+			sda-gpios = <0x1b 0x11 0x06>;
+			phandle = <0x76>;
 
 			i2c-mux@74 {
 				compatible = "nxp,pca9548";
@@ -1378,26 +1373,26 @@
 						reg = <0x54>;
 						#address-cells = <0x01>;
 						#size-cells = <0x01>;
-						phandle = <0x87>;
+						phandle = <0x77>;
 
 						board-sn@0 {
 							reg = <0x00 0x14>;
-							phandle = <0x88>;
+							phandle = <0x78>;
 						};
 
 						eth-mac@20 {
 							reg = <0x20 0x06>;
-							phandle = <0x89>;
+							phandle = <0x79>;
 						};
 
 						board-name@d0 {
 							reg = <0xd0 0x06>;
-							phandle = <0x8a>;
+							phandle = <0x7a>;
 						};
 
 						board-revision@e0 {
 							reg = <0xe0 0x03>;
-							phandle = <0x8b>;
+							phandle = <0x7b>;
 						};
 					};
 				};
@@ -1413,57 +1408,57 @@
 						#clock-cells = <0x02>;
 						#address-cells = <0x01>;
 						#size-cells = <0x00>;
-						clocks = <0x18>;
+						clocks = <0x1e>;
 						clock-names = "xtal";
 						clock-output-names = "si5341";
-						phandle = <0x1c>;
+						phandle = <0x22>;
 
 						out@0 {
 							reg = <0x00>;
 							always-on;
-							phandle = <0x8c>;
+							phandle = <0x7c>;
 						};
 
 						out@2 {
 							reg = <0x02>;
 							always-on;
-							phandle = <0x8d>;
+							phandle = <0x7d>;
 						};
 
 						out@3 {
 							reg = <0x03>;
 							always-on;
-							phandle = <0x8e>;
+							phandle = <0x7e>;
 						};
 
 						out@4 {
 							reg = <0x04>;
 							always-on;
-							phandle = <0x8f>;
+							phandle = <0x7f>;
 						};
 
 						out@5 {
 							reg = <0x05>;
 							always-on;
-							phandle = <0x90>;
+							phandle = <0x80>;
 						};
 
 						out@6 {
 							reg = <0x06>;
 							always-on;
-							phandle = <0x91>;
+							phandle = <0x81>;
 						};
 
 						out@7 {
 							reg = <0x07>;
 							always-on;
-							phandle = <0x92>;
+							phandle = <0x82>;
 						};
 
 						out@9 {
 							reg = <0x09>;
 							always-on;
-							phandle = <0x93>;
+							phandle = <0x83>;
 						};
 					};
 				};
@@ -1481,7 +1476,7 @@
 						factory-fout = <0x11e1a300>;
 						clock-frequency = <0x11e1a300>;
 						clock-output-names = "si570_user";
-						phandle = <0x94>;
+						phandle = <0x84>;
 					};
 				};
 
@@ -1498,7 +1493,7 @@
 						factory-fout = <0x9502f90>;
 						clock-frequency = <0x8d9ee20>;
 						clock-output-names = "si570_mgt";
-						phandle = <0x95>;
+						phandle = <0x85>;
 					};
 				};
 
@@ -1513,15 +1508,15 @@
 						#address-cells = <0x01>;
 						#size-cells = <0x00>;
 						#clock-cells = <0x01>;
-						clocks = <0x19>;
+						clocks = <0x1f>;
 						clock-names = "xtal";
 						clock-output-names = "si5328";
-						phandle = <0x96>;
+						phandle = <0x86>;
 
 						clk0@0 {
 							reg = <0x00>;
 							clock-frequency = <0x19bfcc0>;
-							phandle = <0x97>;
+							phandle = <0x87>;
 						};
 					};
 				};
@@ -1586,16 +1581,16 @@
 		memory-controller@ff960000 {
 			compatible = "xlnx,zynqmp-ocmc-1.0";
 			reg = <0x00 0xff960000 0x00 0x1000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x0a 0x04>;
-			phandle = <0x98>;
+			phandle = <0x88>;
 		};
 
 		perf-monitor@ffa00000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xffa00000 0x00 0x10000>;
 			interrupts = <0x00 0x19 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x01>;
@@ -1607,15 +1602,15 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x99>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x89>;
 		};
 
 		perf-monitor@fd0b0000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xfd0b0000 0x00 0x10000>;
 			interrupts = <0x00 0x7b 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x06>;
@@ -1627,15 +1622,15 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1c>;
-			phandle = <0x9a>;
+			clocks = <0x04 0x1c>;
+			phandle = <0x8a>;
 		};
 
 		perf-monitor@fd490000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xfd490000 0x00 0x10000>;
 			interrupts = <0x00 0x7b 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x01>;
@@ -1647,15 +1642,15 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1c>;
-			phandle = <0x9b>;
+			clocks = <0x04 0x1c>;
+			phandle = <0x8b>;
 		};
 
 		perf-monitor@ffa10000 {
 			compatible = "xlnx,axi-perf-monitor";
 			reg = <0x00 0xffa10000 0x00 0x10000>;
 			interrupts = <0x00 0x19 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			xlnx,enable-profile = <0x00>;
 			xlnx,enable-trace = <0x00>;
 			xlnx,num-monitor-slots = <0x01>;
@@ -1667,8 +1662,8 @@
 			xlnx,metrics-sample-count-width = <0x20>;
 			xlnx,global-count-width = <0x20>;
 			xlnx,metric-count-scale = <0x01>;
-			clocks = <0x03 0x1f>;
-			phandle = <0x9c>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x8c>;
 		};
 
 		pcie@fd0e0000 {
@@ -1679,20 +1674,19 @@
 			#interrupt-cells = <0x01>;
 			msi-controller;
 			device_type = "pci";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x76 0x04 0x00 0x75 0x04 0x00 0x74 0x04 0x00 0x73 0x04 0x00 0x72 0x04>;
 			interrupt-names = "misc\0dummy\0intx\0msi1\0msi0";
-			msi-parent = <0x1a>;
-			reg = <0x00 0xfd0e0000 0x00 0x1000 0x00 0xfd480000 0x00 0x1000 0x80 0x00 0x00 0x1000000>;
+			msi-parent = <0x20>;
+			reg = <0x00 0xfd0e0000 0x00 0x1000 0x00 0xfd480000 0x00 0x1000 0x80 0x00 0x00 0x10000000>;
 			reg-names = "breg\0pcireg\0cfg";
 			ranges = <0x2000000 0x00 0xe0000000 0x00 0xe0000000 0x00 0x10000000 0x43000000 0x06 0x00 0x06 0x00 0x02 0x00>;
 			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
 			bus-range = <0x00 0xff>;
-			interrupt-map = <0x00 0x00 0x00 0x01 0x1b 0x01 0x00 0x00 0x00 0x02 0x1b 0x02 0x00 0x00 0x00 0x03 0x1b 0x03 0x00 0x00 0x00 0x04 0x1b 0x04>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x4d0>;
-			power-domains = <0x0c 0x3b>;
-			clocks = <0x03 0x17>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x21 0x01 0x00 0x00 0x00 0x02 0x21 0x02 0x00 0x00 0x00 0x03 0x21 0x03 0x00 0x00 0x00 0x04 0x21 0x04>;
+			iommus = <0x14 0x4d0>;
+			power-domains = <0x12 0x3b>;
+			clocks = <0x04 0x17>;
 			xlnx,bar0-enable = <0x00>;
 			xlnx,bar1-enable = <0x00>;
 			xlnx,bar2-enable = <0x00>;
@@ -1701,13 +1695,13 @@
 			xlnx,bar5-enable = <0x00>;
 			xlnx,pcie-mode = "Root Port";
 			xlnx,tz-nonsecure = <0x00>;
-			phandle = <0x1a>;
+			phandle = <0x20>;
 
 			legacy-interrupt-controller {
 				interrupt-controller;
 				#address-cells = <0x00>;
 				#interrupt-cells = <0x01>;
-				phandle = <0x1b>;
+				phandle = <0x21>;
 			};
 		};
 
@@ -1717,47 +1711,43 @@
 			status = "okay";
 			clock-names = "ref_clk\0pclk";
 			interrupts = <0x00 0x0f 0x04>;
-			interrupt-parent = <0x04>;
-			num-cs = <0x01>;
+			interrupt-parent = <0x05>;
+			num-cs = <0x02>;
 			reg = <0x00 0xff0f0000 0x00 0x1000 0x00 0xc0000000 0x00 0x8000000>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x873>;
-			power-domains = <0x0c 0x2d>;
-			clocks = <0x03 0x35 0x03 0x1f>;
+			iommus = <0x14 0x873>;
+			power-domains = <0x12 0x2d>;
+			clocks = <0x04 0x35 0x04 0x1f>;
 			is-dual = <0x01>;
 			spi-rx-bus-width = <0x04>;
 			spi-tx-bus-width = <0x04>;
-			phandle = <0x9d>;
+			phandle = <0x8d>;
 
 			flash@0 {
 				compatible = "m25p80\0jedec,spi-nor";
 				#address-cells = <0x01>;
 				#size-cells = <0x01>;
-				reg = <0x00>;
+				reg = <0x00 0x01>;
+				parallel-memories = <0x00 0x4000000 0x00 0x4000000>;
 				spi-tx-bus-width = <0x04>;
 				spi-rx-bus-width = <0x04>;
 				spi-max-frequency = <0x66ff300>;
+				phandle = <0x8e>;
 
 				partition@0 {
-					label = "qspi-fsbl-uboot";
-					reg = <0x00 0x100000>;
+					label = "qspi-boot";
+					reg = <0x00 0x1e00000>;
 				};
 
-				partition@100000 {
-					label = "qspi-linux";
-					reg = <0x100000 0x500000>;
+				partition@1 {
+					label = "qspi-bootenv";
+					reg = <0x1e00000 0x40000>;
 				};
 
-				partition@600000 {
-					label = "qspi-device-tree";
-					reg = <0x600000 0x20000>;
-				};
-
-				partition@620000 {
-					label = "qspi-rootfs";
-					reg = <0x620000 0x5e0000>;
+				partition@2 {
+					label = "qspi-kernel";
+					reg = <0x1e40000 0x2400000>;
 				};
 			};
 		};
@@ -1768,32 +1758,31 @@
 			reg = <0x00 0xfd400000 0x00 0x40000 0x00 0xfd3d0000 0x00 0x1000>;
 			reg-names = "serdes\0siou";
 			#phy-cells = <0x04>;
-			clocks = <0x1c 0x00 0x05 0x1c 0x00 0x03 0x1c 0x00 0x02 0x1c 0x00 0x00>;
+			clocks = <0x22 0x00 0x05 0x22 0x00 0x03 0x22 0x00 0x02 0x22 0x00 0x00>;
 			clock-names = "ref0\0ref1\0ref2\0ref3";
-			phandle = <0x22>;
+			phandle = <0x23>;
 		};
 
 		rtc@ffa60000 {
 			compatible = "xlnx,zynqmp-rtc";
 			status = "okay";
 			reg = <0x00 0xffa60000 0x00 0x100>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x1a 0x04 0x00 0x1b 0x04>;
 			interrupt-names = "alarm\0sec";
 			calibration = <0x7fff>;
-			phandle = <0x9e>;
+			phandle = <0x8f>;
 		};
 
 		ahci@fd0c0000 {
 			compatible = "ceva,ahci-1v84";
 			status = "okay";
 			reg = <0x00 0xfd0c0000 0x00 0x2000>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x85 0x04>;
-			power-domains = <0x0c 0x1c>;
-			resets = <0x0f 0x10>;
-			#stream-id-cells = <0x04>;
-			clocks = <0x03 0x16>;
+			power-domains = <0x12 0x1c>;
+			resets = <0x11 0x10>;
+			clocks = <0x04 0x16>;
 			ceva,p0-cominit-params = <0x18401828>;
 			ceva,p0-comwake-params = <0x614080e>;
 			ceva,p0-burst-params = <0x13084a06>;
@@ -1802,54 +1791,52 @@
 			ceva,p1-comwake-params = <0x614080e>;
 			ceva,p1-burst-params = <0x13084a06>;
 			ceva,p1-retry-params = <0x96a43ffc>;
+			phy-names = "sata-phy";
+			phys = <0x23 0x03 0x01 0x01 0x01>;
 			xlnx,tz-nonsecure-sata0 = <0x00>;
 			xlnx,tz-nonsecure-sata1 = <0x00>;
-			phandle = <0x9f>;
+			phandle = <0x90>;
 		};
 
 		mmc@ff160000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-8.9a\0arasan,sdhci-8.9a";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x30 0x04>;
 			reg = <0x00 0xff160000 0x00 0x1000>;
 			clock-names = "clk_xin\0clk_ahb";
-			xlnx,device_id = <0x00>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x870>;
-			power-domains = <0x0c 0x27>;
+			iommus = <0x14 0x870>;
+			power-domains = <0x12 0x27>;
 			#clock-cells = <0x01>;
 			clock-output-names = "clk_out_sd0\0clk_in_sd0";
-			resets = <0x0f 0x26>;
-			clocks = <0x03 0x36 0x03 0x1f>;
-			assigned-clocks = <0x03 0x36>;
-			phandle = <0xa0>;
+			resets = <0x11 0x26>;
+			clocks = <0x04 0x36 0x04 0x1f>;
+			assigned-clocks = <0x04 0x36>;
+			phandle = <0x91>;
 		};
 
 		mmc@ff170000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-8.9a\0arasan,sdhci-8.9a";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x31 0x04>;
 			reg = <0x00 0xff170000 0x00 0x1000>;
 			clock-names = "clk_xin\0clk_ahb";
-			xlnx,device_id = <0x01>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0x871>;
-			power-domains = <0x0c 0x28>;
+			iommus = <0x14 0x871>;
+			power-domains = <0x12 0x28>;
 			#clock-cells = <0x01>;
 			clock-output-names = "clk_out_sd1\0clk_in_sd1";
-			resets = <0x0f 0x27>;
-			clocks = <0x03 0x37 0x03 0x1f>;
-			assigned-clocks = <0x03 0x37>;
-			pinctrl-names = "default";
-			pinctrl-0 = <0x1d>;
+			resets = <0x11 0x27>;
+			clocks = <0x04 0x37 0x04 0x1f>;
+			assigned-clocks = <0x04 0x37>;
 			no-1-8-v;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x24>;
 			clock-frequency = <0xb2cbcae>;
 			xlnx,mio-bank = <0x01>;
-			phandle = <0xa1>;
+			phandle = <0x92>;
 		};
 
 		smmu@fd800000 {
@@ -1858,250 +1845,246 @@
 			#iommu-cells = <0x01>;
 			status = "disabled";
 			#global-interrupts = <0x01>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04 0x00 0x9b 0x04>;
-			phandle = <0x0e>;
+			phandle = <0x14>;
 		};
 
 		spi@ff040000 {
 			compatible = "cdns,spi-r1p6";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x13 0x04>;
 			reg = <0x00 0xff040000 0x00 0x1000>;
 			clock-names = "ref_clk\0pclk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x23>;
-			clocks = <0x03 0x3a 0x03 0x1f>;
-			phandle = <0xa2>;
+			power-domains = <0x12 0x23>;
+			clocks = <0x04 0x3a 0x04 0x1f>;
+			phandle = <0x93>;
 		};
 
 		spi@ff050000 {
 			compatible = "cdns,spi-r1p6";
 			status = "disabled";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x14 0x04>;
 			reg = <0x00 0xff050000 0x00 0x1000>;
 			clock-names = "ref_clk\0pclk";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			power-domains = <0x0c 0x24>;
-			clocks = <0x03 0x3b 0x03 0x1f>;
-			phandle = <0xa3>;
+			power-domains = <0x12 0x24>;
+			clocks = <0x04 0x3b 0x04 0x1f>;
+			phandle = <0x94>;
 		};
 
 		timer@ff110000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x24 0x04 0x00 0x25 0x04 0x00 0x26 0x04>;
 			reg = <0x00 0xff110000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x18>;
-			clocks = <0x03 0x1f>;
-			phandle = <0xa4>;
+			power-domains = <0x12 0x18>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x95>;
 		};
 
 		timer@ff120000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x27 0x04 0x00 0x28 0x04 0x00 0x29 0x04>;
 			reg = <0x00 0xff120000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x19>;
-			clocks = <0x03 0x1f>;
-			phandle = <0xa5>;
+			power-domains = <0x12 0x19>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x96>;
 		};
 
 		timer@ff130000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x2a 0x04 0x00 0x2b 0x04 0x00 0x2c 0x04>;
 			reg = <0x00 0xff130000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x1a>;
-			clocks = <0x03 0x1f>;
-			phandle = <0xa6>;
+			power-domains = <0x12 0x1a>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x97>;
 		};
 
 		timer@ff140000 {
 			compatible = "cdns,ttc";
-			status = "disabled";
-			interrupt-parent = <0x04>;
+			status = "okay";
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x2d 0x04 0x00 0x2e 0x04 0x00 0x2f 0x04>;
 			reg = <0x00 0xff140000 0x00 0x1000>;
 			timer-width = <0x20>;
-			power-domains = <0x0c 0x1b>;
-			clocks = <0x03 0x1f>;
-			phandle = <0xa7>;
+			power-domains = <0x12 0x1b>;
+			clocks = <0x04 0x1f>;
+			phandle = <0x98>;
 		};
 
 		serial@ff000000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-uart\0cdns,uart-r1p12";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x15 0x04>;
 			reg = <0x00 0xff000000 0x00 0x1000>;
 			clock-names = "uart_clk\0pclk";
-			power-domains = <0x0c 0x21>;
-			clocks = <0x03 0x38 0x03 0x1f>;
+			power-domains = <0x12 0x21>;
+			clocks = <0x04 0x38 0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x1e>;
+			pinctrl-0 = <0x25>;
 			cts-override;
 			device_type = "serial";
 			port-number = <0x00>;
-			phandle = <0xa8>;
+			phandle = <0x99>;
 		};
 
 		serial@ff010000 {
 			u-boot,dm-pre-reloc;
 			compatible = "xlnx,zynqmp-uart\0cdns,uart-r1p12";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x16 0x04>;
 			reg = <0x00 0xff010000 0x00 0x1000>;
 			clock-names = "uart_clk\0pclk";
-			power-domains = <0x0c 0x22>;
-			clocks = <0x03 0x39 0x03 0x1f>;
+			power-domains = <0x12 0x22>;
+			clocks = <0x04 0x39 0x04 0x1f>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x1f>;
+			pinctrl-0 = <0x26>;
 			cts-override;
 			device_type = "serial";
 			port-number = <0x01>;
-			phandle = <0xa9>;
+			phandle = <0x9a>;
 		};
 
-		usb0@ff9d0000 {
+		usb@ff9d0000 {
 			#address-cells = <0x02>;
 			#size-cells = <0x02>;
 			status = "okay";
 			compatible = "xlnx,zynqmp-dwc3";
 			reg = <0x00 0xff9d0000 0x00 0x100>;
 			clock-names = "bus_clk\0ref_clk";
-			power-domains = <0x0c 0x16>;
-			resets = <0x0f 0x3b 0x0f 0x3d 0x0f 0x3f>;
+			power-domains = <0x12 0x16>;
+			resets = <0x11 0x3b 0x11 0x3d 0x11 0x3f>;
 			reset-names = "usb_crst\0usb_hibrst\0usb_apbrst";
-			reset-gpios = <0x20 0x01 0x01>;
+			reset-gpios = <0x27 0x01 0x01>;
 			ranges;
-			clocks = <0x03 0x20 0x03 0x22>;
-			assigned-clocks = <0x03 0x20 0x03 0x22>;
+			clocks = <0x04 0x20 0x04 0x22>;
+			assigned-clocks = <0x04 0x20 0x04 0x22>;
 			pinctrl-names = "default";
-			pinctrl-0 = <0x21>;
+			pinctrl-0 = <0x28>;
 			phy-names = "usb3-phy";
-			phys = <0x22 0x02 0x04 0x00 0x02>;
+			phys = <0x23 0x02 0x04 0x00 0x02>;
 			xlnx,tz-nonsecure = <0x01>;
 			xlnx,usb-polarity = <0x00>;
 			xlnx,usb-reset-mode = <0x00>;
-			phandle = <0xaa>;
+			phandle = <0x9b>;
 
 			usb@fe200000 {
 				compatible = "snps,dwc3";
 				status = "okay";
 				reg = <0x00 0xfe200000 0x00 0x40000>;
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupt-names = "dwc_usb3\0otg\0hiber";
 				interrupts = <0x00 0x41 0x04 0x00 0x45 0x04 0x00 0x4b 0x04>;
-				#stream-id-cells = <0x01>;
-				iommus = <0x0e 0x860>;
+				iommus = <0x14 0x860>;
 				snps,quirk-frame-length-adjustment = <0x20>;
-				snps,refclk_fladj;
-				snps,enable_guctl1_resume_quirk;
+				clock-names = "ref";
 				snps,enable_guctl1_ipd_quirk;
-				snps,xhci-stream-quirk;
+				snps,resume-hs-terminations;
+				clocks = <0x04 0x22>;
 				dr_mode = "host";
 				snps,usb3_lpm_capable;
 				maximum-speed = "super-speed";
-				phandle = <0xab>;
+				phandle = <0x9c>;
 			};
 		};
 
-		usb1@ff9e0000 {
+		usb@ff9e0000 {
 			#address-cells = <0x02>;
 			#size-cells = <0x02>;
 			status = "disabled";
 			compatible = "xlnx,zynqmp-dwc3";
 			reg = <0x00 0xff9e0000 0x00 0x100>;
 			clock-names = "bus_clk\0ref_clk";
-			power-domains = <0x0c 0x17>;
-			resets = <0x0f 0x3c 0x0f 0x3e 0x0f 0x40>;
+			power-domains = <0x12 0x17>;
+			resets = <0x11 0x3c 0x11 0x3e 0x11 0x40>;
 			reset-names = "usb_crst\0usb_hibrst\0usb_apbrst";
 			ranges;
-			clocks = <0x03 0x21 0x03 0x22>;
-			assigned-clocks = <0x03 0x21 0x03 0x22>;
-			phandle = <0xac>;
+			clocks = <0x04 0x21 0x04 0x22>;
+			assigned-clocks = <0x04 0x21 0x04 0x22>;
+			phandle = <0x9d>;
 
 			usb@fe300000 {
 				compatible = "snps,dwc3";
 				status = "disabled";
 				reg = <0x00 0xfe300000 0x00 0x40000>;
-				interrupt-parent = <0x04>;
+				interrupt-parent = <0x05>;
 				interrupt-names = "dwc_usb3\0otg\0hiber";
 				interrupts = <0x00 0x46 0x04 0x00 0x4a 0x04 0x00 0x4c 0x04>;
-				#stream-id-cells = <0x01>;
-				iommus = <0x0e 0x861>;
+				iommus = <0x14 0x861>;
 				snps,quirk-frame-length-adjustment = <0x20>;
-				snps,refclk_fladj;
-				snps,enable_guctl1_resume_quirk;
+				clock-names = "ref";
 				snps,enable_guctl1_ipd_quirk;
-				snps,xhci-stream-quirk;
-				phandle = <0xad>;
+				snps,resume-hs-terminations;
+				clocks = <0x04 0x22>;
+				phandle = <0x9e>;
 			};
 		};
 
 		watchdog@fd4d0000 {
 			compatible = "cdns,wdt-r1p2";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x71 0x01>;
 			reg = <0x00 0xfd4d0000 0x00 0x1000>;
 			timeout-sec = <0x3c>;
 			reset-on-timeout;
-			clocks = <0x03 0x4b>;
-			phandle = <0xae>;
+			clocks = <0x04 0x4b>;
+			phandle = <0x9f>;
 		};
 
 		watchdog@ff150000 {
 			compatible = "cdns,wdt-r1p2";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x34 0x01>;
 			reg = <0x00 0xff150000 0x00 0x1000>;
 			timeout-sec = <0x0a>;
-			clocks = <0x03 0x70>;
-			phandle = <0xaf>;
+			clocks = <0x04 0x70>;
+			phandle = <0xa0>;
 		};
 
 		ams@ffa50000 {
 			compatible = "xlnx,zynqmp-ams";
 			status = "okay";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x38 0x04>;
-			interrupt-names = "ams-irq";
 			reg = <0x00 0xffa50000 0x00 0x800>;
-			reg-names = "ams-base";
-			#address-cells = <0x02>;
-			#size-cells = <0x02>;
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
 			#io-channel-cells = <0x01>;
-			ranges;
-			clocks = <0x03 0x46>;
-			phandle = <0xb0>;
+			ranges = <0x00 0x00 0xffa50800 0x800>;
+			clocks = <0x04 0x46>;
+			phandle = <0xa1>;
 
-			ams_ps@ffa50800 {
+			ams-ps@0 {
 				compatible = "xlnx,zynqmp-ams-ps";
 				status = "okay";
-				reg = <0x00 0xffa50800 0x00 0x400>;
-				phandle = <0xb1>;
+				reg = <0x00 0x400>;
+				phandle = <0xa2>;
 			};
 
-			ams_pl@ffa50c00 {
+			ams-pl@400 {
 				compatible = "xlnx,zynqmp-ams-pl";
 				status = "okay";
-				reg = <0x00 0xffa50c00 0x00 0x400>;
-				phandle = <0xb2>;
+				reg = <0x400 0x400>;
+				phandle = <0xa3>;
 			};
 		};
 
@@ -2110,22 +2093,21 @@
 			status = "okay";
 			reg = <0x00 0xfd4c0000 0x00 0x1000>;
 			interrupts = <0x00 0x7a 0x04>;
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			clock-names = "axi_clk";
-			power-domains = <0x0c 0x29>;
+			power-domains = <0x12 0x29>;
 			dma-channels = <0x06>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0xce4>;
+			iommus = <0x14 0xce4>;
 			#dma-cells = <0x01>;
-			clocks = <0x03 0x14>;
-			assigned-clocks = <0x03 0x14>;
-			phandle = <0x24>;
+			clocks = <0x04 0x14>;
+			assigned-clocks = <0x04 0x14>;
+			phandle = <0x2a>;
 		};
 
-		dp_aud@fd4ac000 {
+		dp-aud@fd4ac000 {
 			compatible = "xlnx,zynqmp-dpaud-setting\0syscon";
 			reg = <0x00 0xfd4ac000 0x00 0x1000>;
-			phandle = <0x23>;
+			phandle = <0x29>;
 		};
 
 		display@fd4a0000 {
@@ -2134,56 +2116,55 @@
 			status = "okay";
 			reg = <0x00 0xfd4a0000 0x00 0x1000 0x00 0xfd4aa000 0x00 0x1000 0x00 0xfd4ab000 0x00 0x1000>;
 			reg-names = "dp\0blend\0av_buf";
-			xlnx,dpaud-reg = <0x23>;
+			xlnx,dpaud-reg = <0x29>;
 			interrupts = <0x00 0x77 0x04>;
-			interrupt-parent = <0x04>;
-			#stream-id-cells = <0x01>;
-			iommus = <0x0e 0xce3>;
+			interrupt-parent = <0x05>;
+			iommus = <0x14 0xce3>;
 			clock-names = "dp_apb_clk\0dp_aud_clk\0dp_vtc_pixel_clk_in";
-			power-domains = <0x0c 0x29>;
-			resets = <0x0f 0x03>;
+			power-domains = <0x12 0x29>;
+			resets = <0x11 0x03>;
 			dma-names = "vid0\0vid1\0vid2\0gfx0";
-			dmas = <0x24 0x00 0x24 0x01 0x24 0x02 0x24 0x03>;
-			clocks = <0x25 0x03 0x11 0x03 0x10>;
-			assigned-clocks = <0x03 0x12 0x03 0x11 0x03 0x10>;
+			dmas = <0x2a 0x00 0x2a 0x01 0x2a 0x02 0x2a 0x03>;
+			clocks = <0x04 0x1c 0x04 0x11 0x04 0x10>;
+			assigned-clocks = <0x04 0x12 0x04 0x11 0x04 0x10>;
 			phy-names = "dp-phy0";
-			phys = <0x22 0x01 0x06 0x00 0x03>;
+			phys = <0x23 0x01 0x06 0x00 0x03>;
 			xlnx,max-lanes = <0x01>;
-			phandle = <0xb3>;
+			phandle = <0xa4>;
 
 			i2c-bus {
 			};
 
-			zynqmp_dp_snd_codec0 {
+			zynqmp-dp-snd-codec0 {
 				compatible = "xlnx,dp-snd-codec";
 				clock-names = "aud_clk";
-				clocks = <0x03 0x11>;
+				clocks = <0x04 0x11>;
 				status = "okay";
-				phandle = <0x28>;
+				phandle = <0x2d>;
 			};
 
-			zynqmp_dp_snd_pcm0 {
+			zynqmp-dp-snd-pcm0 {
 				compatible = "xlnx,dp-snd-pcm0";
-				dmas = <0x24 0x04>;
+				dmas = <0x2a 0x04>;
 				dma-names = "tx";
 				status = "okay";
-				phandle = <0x26>;
+				phandle = <0x2b>;
 			};
 
-			zynqmp_dp_snd_pcm1 {
+			zynqmp-dp-snd-pcm1 {
 				compatible = "xlnx,dp-snd-pcm1";
-				dmas = <0x24 0x05>;
+				dmas = <0x2a 0x05>;
 				dma-names = "tx";
 				status = "okay";
-				phandle = <0x27>;
+				phandle = <0x2c>;
 			};
 
-			zynqmp_dp_snd_card {
+			zynqmp-dp-snd-card {
 				compatible = "xlnx,dp-snd-card";
-				xlnx,dp-snd-pcm = <0x26 0x27>;
-				xlnx,dp-snd-codec = <0x28>;
+				xlnx,dp-snd-pcm = <0x2b 0x2c>;
+				xlnx,dp-snd-codec = <0x2d>;
 				status = "okay";
-				phandle = <0xb4>;
+				phandle = <0xa5>;
 			};
 		};
 	};
@@ -2191,29 +2172,29 @@
 	fclk0 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x47>;
-		phandle = <0xb5>;
+		clocks = <0x04 0x47>;
+		phandle = <0xa6>;
 	};
 
 	fclk1 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x48>;
-		phandle = <0xb6>;
+		clocks = <0x04 0x48>;
+		phandle = <0xa7>;
 	};
 
 	fclk2 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x49>;
-		phandle = <0xb7>;
+		clocks = <0x04 0x49>;
+		phandle = <0xa8>;
 	};
 
 	fclk3 {
 		status = "okay";
 		compatible = "xlnx,fclk";
-		clocks = <0x03 0x4a>;
-		phandle = <0xb8>;
+		clocks = <0x04 0x4a>;
+		phandle = <0xa9>;
 	};
 
 	pss_ref_clk {
@@ -2221,7 +2202,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x1fc9350>;
-		phandle = <0x06>;
+		phandle = <0x0b>;
 	};
 
 	video_clk {
@@ -2229,7 +2210,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x1fc9f08>;
-		phandle = <0x07>;
+		phandle = <0x0c>;
 	};
 
 	pss_alt_ref_clk {
@@ -2237,7 +2218,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x00>;
-		phandle = <0x08>;
+		phandle = <0x0d>;
 	};
 
 	gt_crx_ref_clk {
@@ -2245,7 +2226,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x66ff300>;
-		phandle = <0x0a>;
+		phandle = <0x0f>;
 	};
 
 	aux_ref_clk {
@@ -2253,26 +2234,30 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x19bfcc0>;
-		phandle = <0x09>;
+		phandle = <0x0e>;
 	};
 
-	dp_aclk {
-		compatible = "fixed-clock";
-		#clock-cells = <0x00>;
-		clock-frequency = <0x5f5e100>;
-		clock-accuracy = <0x64>;
-		phandle = <0x25>;
+	aliases {
+		ethernet0 = "/axi/ethernet@ff0e0000";
+		i2c0 = "/axi/i2c@ff020000";
+		i2c1 = "/axi/i2c@ff030000";
+		mmc0 = "/axi/mmc@ff170000";
+		nvmem0 = "/axi/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
+		rtc0 = "/axi/rtc@ffa60000";
+		serial0 = "/axi/serial@ff000000";
+		serial1 = "/axi/serial@ff010000";
+		serial2 = "/dcc";
+		spi0 = "/axi/spi@ff0f0000";
+		usb0 = "/axi/usb@ff9d0000";
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
-		#address-cells = <0x01>;
-		#size-cells = <0x00>;
 		autorepeat;
 
-		sw19 {
+		switch-19 {
 			label = "sw19";
-			gpios = <0x15 0x16 0x00>;
+			gpios = <0x1b 0x16 0x00>;
 			linux,code = <0x6c>;
 			wakeup-source;
 			autorepeat;
@@ -2284,119 +2269,113 @@
 
 		heartbeat-led {
 			label = "heartbeat";
-			gpios = <0x15 0x17 0x00>;
+			gpios = <0x1b 0x17 0x00>;
 			linux,default-trigger = "heartbeat";
 		};
 	};
 
-	chosen {
-		nvmem0 = "/axi/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
-		bootargs = "earlycon";
-		stdout-path = "serial0:115200n8";
-	};
-
 	ina226-u76 {
-		compatible = "iio-hwmon";
-		io-channels = <0x29 0x00 0x29 0x01 0x29 0x02 0x29 0x03>;
-	};
-
-	ina226-u77 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2a 0x00 0x2a 0x01 0x2a 0x02 0x2a 0x03>;
-	};
-
-	ina226-u78 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2b 0x00 0x2b 0x01 0x2b 0x02 0x2b 0x03>;
-	};
-
-	ina226-u87 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2c 0x00 0x2c 0x01 0x2c 0x02 0x2c 0x03>;
-	};
-
-	ina226-u85 {
-		compatible = "iio-hwmon";
-		io-channels = <0x2d 0x00 0x2d 0x01 0x2d 0x02 0x2d 0x03>;
-	};
-
-	ina226-u86 {
 		compatible = "iio-hwmon";
 		io-channels = <0x2e 0x00 0x2e 0x01 0x2e 0x02 0x2e 0x03>;
 	};
 
-	ina226-u93 {
+	ina226-u77 {
 		compatible = "iio-hwmon";
 		io-channels = <0x2f 0x00 0x2f 0x01 0x2f 0x02 0x2f 0x03>;
 	};
 
-	ina226-u88 {
+	ina226-u78 {
 		compatible = "iio-hwmon";
 		io-channels = <0x30 0x00 0x30 0x01 0x30 0x02 0x30 0x03>;
 	};
 
-	ina226-u15 {
+	ina226-u87 {
 		compatible = "iio-hwmon";
 		io-channels = <0x31 0x00 0x31 0x01 0x31 0x02 0x31 0x03>;
 	};
 
-	ina226-u92 {
+	ina226-u85 {
 		compatible = "iio-hwmon";
 		io-channels = <0x32 0x00 0x32 0x01 0x32 0x02 0x32 0x03>;
 	};
 
-	ina226-u79 {
+	ina226-u86 {
 		compatible = "iio-hwmon";
 		io-channels = <0x33 0x00 0x33 0x01 0x33 0x02 0x33 0x03>;
 	};
 
-	ina226-u81 {
+	ina226-u93 {
 		compatible = "iio-hwmon";
 		io-channels = <0x34 0x00 0x34 0x01 0x34 0x02 0x34 0x03>;
 	};
 
-	ina226-u80 {
+	ina226-u88 {
 		compatible = "iio-hwmon";
 		io-channels = <0x35 0x00 0x35 0x01 0x35 0x02 0x35 0x03>;
 	};
 
-	ina226-u84 {
+	ina226-u15 {
 		compatible = "iio-hwmon";
 		io-channels = <0x36 0x00 0x36 0x01 0x36 0x02 0x36 0x03>;
 	};
 
-	ina226-u16 {
+	ina226-u92 {
 		compatible = "iio-hwmon";
 		io-channels = <0x37 0x00 0x37 0x01 0x37 0x02 0x37 0x03>;
 	};
 
-	ina226-u65 {
+	ina226-u79 {
 		compatible = "iio-hwmon";
 		io-channels = <0x38 0x00 0x38 0x01 0x38 0x02 0x38 0x03>;
 	};
 
-	ina226-u74 {
+	ina226-u81 {
 		compatible = "iio-hwmon";
 		io-channels = <0x39 0x00 0x39 0x01 0x39 0x02 0x39 0x03>;
 	};
 
-	ina226-u75 {
+	ina226-u80 {
 		compatible = "iio-hwmon";
 		io-channels = <0x3a 0x00 0x3a 0x01 0x3a 0x02 0x3a 0x03>;
+	};
+
+	ina226-u84 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3b 0x00 0x3b 0x01 0x3b 0x02 0x3b 0x03>;
+	};
+
+	ina226-u16 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3c 0x00 0x3c 0x01 0x3c 0x02 0x3c 0x03>;
+	};
+
+	ina226-u65 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3d 0x00 0x3d 0x01 0x3d 0x02 0x3d 0x03>;
+	};
+
+	ina226-u74 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3e 0x00 0x3e 0x01 0x3e 0x02 0x3e 0x03>;
+	};
+
+	ina226-u75 {
+		compatible = "iio-hwmon";
+		io-channels = <0x3f 0x00 0x3f 0x01 0x3f 0x02 0x3f 0x03>;
 	};
 
 	ref48M {
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x2dc6c00>;
-		phandle = <0x18>;
+		phandle = <0x1e>;
 	};
 
 	refhdmi {
 		compatible = "fixed-clock";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x6cfd9c8>;
-		phandle = <0x19>;
+		phandle = <0x1f>;
 	};
 
 	amba_pl@0 {
@@ -2404,208 +2383,44 @@
 		#size-cells = <0x02>;
 		compatible = "simple-bus";
 		ranges;
-		phandle = <0xb9>;
+		phandle = <0xaa>;
 
 		interrupt-controller@80020000 {
 			#interrupt-cells = <0x02>;
 			clock-names = "s_axi_aclk";
-			clocks = <0x3b>;
+			clocks = <0x40>;
 			compatible = "xlnx,axi-intc-4.1\0xlnx,xps-intc-1.00.a";
 			interrupt-controller;
 			interrupt-names = "irq";
-			interrupt-parent = <0x04>;
+			interrupt-parent = <0x05>;
 			interrupts = <0x00 0x59 0x04>;
 			reg = <0x00 0x80020000 0x00 0x1000>;
 			xlnx,kind-of-intr = <0x01>;
 			xlnx,num-intr-inputs = <0x20>;
-			phandle = <0x3c>;
+			phandle = <0x41>;
 		};
 
 		misc_clk_0 {
 			#clock-cells = <0x00>;
 			clock-frequency = <0x4784b74>;
 			compatible = "fixed-clock";
-			phandle = <0x3b>;
+			phandle = <0x40>;
 		};
 
 		zyxclmm_drm {
 			compatible = "xlnx,zocl";
-			interrupts-extended = <0x3c 0x00 0x04 0x3c 0x01 0x04 0x3c 0x02 0x04 0x3c 0x03 0x04 0x3c 0x04 0x04 0x3c 0x05 0x04 0x3c 0x06 0x04 0x3c 0x07 0x04 0x3c 0x08 0x04 0x3c 0x09 0x04 0x3c 0x0a 0x04 0x3c 0x0b 0x04 0x3c 0x0c 0x04 0x3c 0x0d 0x04 0x3c 0x0e 0x04 0x3c 0x0f 0x04 0x3c 0x10 0x04 0x3c 0x11 0x04 0x3c 0x12 0x04 0x3c 0x13 0x04 0x3c 0x14 0x04 0x3c 0x15 0x04 0x3c 0x16 0x04 0x3c 0x17 0x04 0x3c 0x18 0x04 0x3c 0x19 0x04 0x3c 0x1a 0x04 0x3c 0x1b 0x04 0x3c 0x1c 0x04 0x3c 0x1d 0x04 0x3c 0x1e 0x04 0x3c 0x1f 0x04>;
+			interrupts-extended = <0x41 0x00 0x04 0x41 0x01 0x04 0x41 0x02 0x04 0x41 0x03 0x04 0x41 0x04 0x04 0x41 0x05 0x04 0x41 0x06 0x04 0x41 0x07 0x04 0x41 0x08 0x04 0x41 0x09 0x04 0x41 0x0a 0x04 0x41 0x0b 0x04 0x41 0x0c 0x04 0x41 0x0d 0x04 0x41 0x0e 0x04 0x41 0x0f 0x04 0x41 0x10 0x04 0x41 0x11 0x04 0x41 0x12 0x04 0x41 0x13 0x04 0x41 0x14 0x04 0x41 0x15 0x04 0x41 0x16 0x04 0x41 0x17 0x04 0x41 0x18 0x04 0x41 0x19 0x04 0x41 0x1a 0x04 0x41 0x1b 0x04 0x41 0x1c 0x04 0x41 0x1d 0x04 0x41 0x1e 0x04 0x41 0x1f 0x04>;
 		};
 	};
 
-	aliases {
-		ethernet0 = "/axi/ethernet@ff0e0000";
-		i2c0 = "/axi/i2c@ff020000";
-		i2c1 = "/axi/i2c@ff030000";
-		serial0 = "/axi/serial@ff000000";
-		serial1 = "/axi/serial@ff010000";
-		spi0 = "/axi/spi@ff0f0000";
+	chosen {
+		bootargs = "earlycon console=ttyPS0,115200 clk_ignore_unused root=/dev/ram0 rw init_fatal_sh=1";
+		stdout-path = "serial0:115200n8";
 	};
 
-	memory {
+	memory@0 {
 		device_type = "memory";
 		reg = <0x00 0x00 0x00 0x7ff00000 0x08 0x00 0x00 0x80000000>;
-	};
-
-	reserved-memory {
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-
-		rpu0vdev0vring0@3ed40000 {
-			no-map;
-			reg = <0x00 0x3ed40000 0x00 0x4000>;
-			phandle = <0x3f>;
-		};
-
-		rpu0vdev0vring1@3ed44000 {
-			no-map;
-			reg = <0x00 0x3ed44000 0x00 0x4000>;
-			phandle = <0x44>;
-		};
-
-		rpu0vdev0buffer@3ed48000 {
-			no-map;
-			reg = <0x00 0x3ed48000 0x00 0x100000>;
-			phandle = <0x3e>;
-		};
-
-		rproc@3ed00000 {
-			no-map;
-			reg = <0x00 0x3ed00000 0x00 0x40000>;
-			phandle = <0x3d>;
-		};
-
-		rproc@3ef00000 {
-			no-map;
-			reg = <0x00 0x3ef00000 0x00 0x40000>;
-			phandle = <0x46>;
-		};
-
-		rpu1vdev0vring0@3ef40000 {
-			no-map;
-			reg = <0x00 0x3ef40000 0x00 0x4000>;
-			phandle = <0x48>;
-		};
-
-		rpu1vdev0vring1@3ef44000 {
-			no-map;
-			reg = <0x00 0x3ef44000 0x00 0x4000>;
-			phandle = <0x49>;
-		};
-
-		rpu1vdev0buffer@3ef48000 {
-			no-map;
-			compatible = "shared-dma-pool";
-			reg = <0x00 0x3ef48000 0x00 0x100000>;
-			phandle = <0x47>;
-		};
-	};
-
-	tcm_0a@ffe00000 {
-		no-map;
-		reg = <0x00 0xffe00000 0x00 0x10000>;
-		phandle = <0x40>;
-		status = "okay";
-		compatible = "mmio-sram";
-		power-domain = <0x0c 0x0f>;
-	};
-
-	tcm_0b@ffe20000 {
-		no-map;
-		reg = <0x00 0xffe20000 0x00 0x10000>;
-		phandle = <0x41>;
-		status = "okay";
-		compatible = "mmio-sram";
-		power-domain = <0x0c 0x10>;
-	};
-
-	tcm_1a@ffe90000 {
-		no-map;
-		reg = <0x00 0xffe90000 0x00 0x10000>;
-		phandle = <0x42>;
-		status = "okay";
-		compatible = "mmio-sram";
-		power-domain = <0x0c 0x11>;
-	};
-
-	tcm_1b@ffeb0000 {
-		no-map;
-		reg = <0x00 0xffeb0000 0x00 0x10000>;
-		phandle = <0x43>;
-		status = "okay";
-		compatible = "mmio-sram";
-		power-domain = <0x0c 0x12>;
-	};
-
-	rf5ss@ff9a0000 {
-		compatible = "xlnx,zynqmp-r5-remoteproc";
-		xlnx,cluster-mode = <0x01>;
-		ranges;
-		reg = <0x00 0xff9a0000 0x00 0x10000>;
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-
-		r5f_0 {
-			compatible = "xilinx,r5f";
-			#address-cells = <0x02>;
-			#size-cells = <0x02>;
-			ranges;
-			sram = <0x40 0x41>;
-			memory-region = <0x3d 0x3e 0x3f 0x44>;
-			power-domain = <0x0c 0x07>;
-			mboxes = <0x45 0x00 0x45 0x01>;
-			mbox-names = "tx\0rx";
-		};
-
-		r5f_1 {
-			compatible = "xilinx,r5f";
-			#address-cells = <0x02>;
-			#size-cells = <0x02>;
-			ranges;
-			sram = <0x42 0x43>;
-			memory-region = <0x46 0x47 0x48 0x49>;
-			power-domain = <0x0c 0x08>;
-			mboxes = <0x4a 0x00 0x4a 0x01>;
-			mbox-names = "tx\0rx";
-		};
-	};
-
-	zynqmp_ipi1 {
-		compatible = "xlnx,zynqmp-ipi-mailbox";
-		interrupt-parent = <0x04>;
-		interrupts = <0x00 0x1d 0x04>;
-		xlnx,ipi-id = <0x07>;
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-
-		mailbox@ff990600 {
-			reg = <0x00 0xff990600 0x00 0x20 0x00 0xff990620 0x00 0x20 0x00 0xff9900c0 0x00 0x20 0x00 0xff9900e0 0x00 0x20>;
-			reg-names = "local_request_region\0local_response_region\0remote_request_region\0remote_response_region";
-			#mbox-cells = <0x01>;
-			xlnx,ipi-id = <0x01>;
-			phandle = <0x45>;
-		};
-	};
-
-	zynqmp_ipi2 {
-		compatible = "xlnx,zynqmp-ipi-mailbox";
-		interrupt-parent = <0x04>;
-		interrupts = <0x00 0x1e 0x04>;
-		xlnx,ipi-id = <0x08>;
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-
-		mailbox@ff990640 {
-			reg = <0x00 0xff3f0b00 0x00 0x20 0x00 0xff3f0b20 0x00 0x20 0x00 0xff3f0940 0x00 0x20 0x00 0xff3f0960 0x00 0x20>;
-			reg-names = "local_request_region\0local_response_region\0remote_request_region\0remote_response_region";
-			#mbox-cells = <0x01>;
-			xlnx,ipi-id = <0x02>;
-			phandle = <0x4a>;
-		};
 	};
 
 	__symbols__ {
@@ -2613,32 +2428,32 @@
 		cpu1 = "/cpus/cpu@1";
 		cpu2 = "/cpus/cpu@2";
 		cpu3 = "/cpus/cpu@3";
+		L2 = "/cpus/l2-cache";
 		CPU_SLEEP_0 = "/cpus/idle-states/cpu-sleep-0";
-		cpu_opp_table = "/cpu-opp-table";
-		zynqmp_ipi = "/zynqmp_ipi";
-		ipi_mailbox_pmu1 = "/zynqmp_ipi/mailbox@ff990400";
+		cpu_opp_table = "/opp-table-cpu";
+		zynqmp_ipi = "/zynqmp-ipi";
+		ipi_mailbox_pmu1 = "/zynqmp-ipi/mailbox@ff9905c0";
 		dcc = "/dcc";
 		zynqmp_firmware = "/firmware/zynqmp-firmware";
 		zynqmp_power = "/firmware/zynqmp-firmware/zynqmp-power";
-		soc_revision = "/firmware/zynqmp-firmware/nvmem_firmware/soc_revision@0";
-		efuse_dna = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_dna@c";
-		efuse_usr0 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr0@20";
-		efuse_usr1 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr1@24";
-		efuse_usr2 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr2@28";
-		efuse_usr3 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr3@2c";
-		efuse_usr4 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr4@30";
-		efuse_usr5 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr5@34";
-		efuse_usr6 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr6@38";
-		efuse_usr7 = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_usr7@3c";
-		efuse_miscusr = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_miscusr@40";
-		efuse_chash = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_chash@50";
-		efuse_pufmisc = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_pufmisc@54";
-		efuse_sec = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_sec@58";
-		efuse_spkid = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_spkid@5c";
-		efuse_ppk0hash = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_ppk0hash@a0";
-		efuse_ppk1hash = "/firmware/zynqmp-firmware/nvmem_firmware/efuse_ppk1hash@d0";
+		soc_revision = "/firmware/zynqmp-firmware/nvmem-firmware/soc-revision@0";
+		efuse_dna = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-dna@c";
+		efuse_usr0 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr0@20";
+		efuse_usr1 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr1@24";
+		efuse_usr2 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr2@28";
+		efuse_usr3 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr3@2c";
+		efuse_usr4 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr4@30";
+		efuse_usr5 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr5@34";
+		efuse_usr6 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr6@38";
+		efuse_usr7 = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-usr7@3c";
+		efuse_miscusr = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-miscusr@40";
+		efuse_chash = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-chash@50";
+		efuse_pufmisc = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-pufmisc@54";
+		efuse_sec = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-sec@58";
+		efuse_spkid = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-spkid@5c";
+		efuse_ppk0hash = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-ppk0hash@a0";
+		efuse_ppk1hash = "/firmware/zynqmp-firmware/nvmem-firmware/efuse-ppk1hash@d0";
 		zynqmp_pcap = "/firmware/zynqmp-firmware/pcap";
-		xlnx_aes = "/firmware/zynqmp-firmware/zynqmp-aes";
 		zynqmp_reset = "/firmware/zynqmp-firmware/reset-controller";
 		pinctrl0 = "/firmware/zynqmp-firmware/pinctrl";
 		pinctrl_i2c0_default = "/firmware/zynqmp-firmware/pinctrl/i2c0-default";
@@ -2652,8 +2467,6 @@
 		pinctrl_can1_default = "/firmware/zynqmp-firmware/pinctrl/can1-default";
 		pinctrl_sdhci1_default = "/firmware/zynqmp-firmware/pinctrl/sdhci1-default";
 		pinctrl_gpio_default = "/firmware/zynqmp-firmware/pinctrl/gpio-default";
-		xlnx_keccak_384 = "/firmware/zynqmp-firmware/sha384";
-		xlnx_rsa = "/firmware/zynqmp-firmware/zynqmp-rsa";
 		modepin_gpio = "/firmware/zynqmp-firmware/gpio";
 		zynqmp_clk = "/firmware/zynqmp-firmware/clock-controller";
 		fpga_full = "/fpga-full";
@@ -2685,7 +2498,8 @@
 		gem1 = "/axi/ethernet@ff0c0000";
 		gem2 = "/axi/ethernet@ff0d0000";
 		gem3 = "/axi/ethernet@ff0e0000";
-		phyc = "/axi/ethernet@ff0e0000/ethernet-phy@c";
+		mdio = "/axi/ethernet@ff0e0000/mdio";
+		phyc = "/axi/ethernet@ff0e0000/mdio/ethernet-phy@c";
 		gpio = "/axi/gpio@ff0a0000";
 		i2c0 = "/axi/i2c@ff020000";
 		tca6416_u97 = "/axi/i2c@ff020000/gpio@20";
@@ -2735,6 +2549,7 @@
 		pcie = "/axi/pcie@fd0e0000";
 		pcie_intc = "/axi/pcie@fd0e0000/legacy-interrupt-controller";
 		qspi = "/axi/spi@ff0f0000";
+		flash0 = "/axi/spi@ff0f0000/flash@0";
 		psgtr = "/axi/phy@fd400000";
 		rtc = "/axi/rtc@ffa60000";
 		sata = "/axi/ahci@fd0c0000";
@@ -2749,22 +2564,22 @@
 		ttc3 = "/axi/timer@ff140000";
 		uart0 = "/axi/serial@ff000000";
 		uart1 = "/axi/serial@ff010000";
-		usb0 = "/axi/usb0@ff9d0000";
-		dwc3_0 = "/axi/usb0@ff9d0000/usb@fe200000";
-		usb1 = "/axi/usb1@ff9e0000";
-		dwc3_1 = "/axi/usb1@ff9e0000/usb@fe300000";
+		usb0 = "/axi/usb@ff9d0000";
+		dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
+		usb1 = "/axi/usb@ff9e0000";
+		dwc3_1 = "/axi/usb@ff9e0000/usb@fe300000";
 		watchdog0 = "/axi/watchdog@fd4d0000";
 		lpd_watchdog = "/axi/watchdog@ff150000";
 		xilinx_ams = "/axi/ams@ffa50000";
-		ams_ps = "/axi/ams@ffa50000/ams_ps@ffa50800";
-		ams_pl = "/axi/ams@ffa50000/ams_pl@ffa50c00";
+		ams_ps = "/axi/ams@ffa50000/ams-ps@0";
+		ams_pl = "/axi/ams@ffa50000/ams-pl@400";
 		zynqmp_dpdma = "/axi/dma-controller@fd4c0000";
-		zynqmp_dpaud_setting = "/axi/dp_aud@fd4ac000";
+		zynqmp_dpaud_setting = "/axi/dp-aud@fd4ac000";
 		zynqmp_dpsub = "/axi/display@fd4a0000";
-		zynqmp_dp_snd_codec0 = "/axi/display@fd4a0000/zynqmp_dp_snd_codec0";
-		zynqmp_dp_snd_pcm0 = "/axi/display@fd4a0000/zynqmp_dp_snd_pcm0";
-		zynqmp_dp_snd_pcm1 = "/axi/display@fd4a0000/zynqmp_dp_snd_pcm1";
-		zynqmp_dp_snd_card0 = "/axi/display@fd4a0000/zynqmp_dp_snd_card";
+		zynqmp_dp_snd_codec0 = "/axi/display@fd4a0000/zynqmp-dp-snd-codec0";
+		zynqmp_dp_snd_pcm0 = "/axi/display@fd4a0000/zynqmp-dp-snd-pcm0";
+		zynqmp_dp_snd_pcm1 = "/axi/display@fd4a0000/zynqmp-dp-snd-pcm1";
+		zynqmp_dp_snd_card0 = "/axi/display@fd4a0000/zynqmp-dp-snd-card";
 		fclk0 = "/fclk0";
 		fclk1 = "/fclk1";
 		fclk2 = "/fclk2";
@@ -2774,21 +2589,10 @@
 		pss_alt_ref_clk = "/pss_alt_ref_clk";
 		gt_crx_ref_clk = "/gt_crx_ref_clk";
 		aux_ref_clk = "/aux_ref_clk";
-		dp_aclk = "/dp_aclk";
 		ref48 = "/ref48M";
 		refhdmi = "/refhdmi";
 		amba_pl = "/amba_pl@0";
 		axi_intc_0 = "/amba_pl@0/interrupt-controller@80020000";
 		misc_clk_0 = "/amba_pl@0/misc_clk_0";
-		rpu0vdev0vring0 = "/reserved-memory/rpu0vdev0vring0@3ed40000";
-		rpu0vdev0vring1 = "/reserved-memory/rpu0vdev0vring1@3ed44000";
-		rpu0vdev0buffer = "/reserved-memory/rpu0vdev0buffer@3ed48000";
-		rproc_0_reserved = "/reserved-memory/rproc@3ed00000";
-		rproc_1_reserved = "/reserved-memory/rproc@3ef00000";
-		rpu1vdev0vring0 = "/reserved-memory/rpu1vdev0vring0@3ef40000";
-		rpu1vdev0vring1 = "/reserved-memory/rpu1vdev0vring1@3ef44000";
-		rpu1vdev0buffer = "/reserved-memory/rpu1vdev0buffer@3ef48000";
-		ipi_mailbox_rpu0 = "/zynqmp_ipi1/mailbox@ff990600";
-		ipi_mailbox_rpu1 = "/zynqmp_ipi2/mailbox@ff990640";
 	};
 };

--- a/examples/linux/dts/xilinx/zcu102-openamp-split.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-split.dts
@@ -125,6 +125,32 @@
 			xlnx,ipi-id = <0x04>;
 			phandle = <0x0a>;
 		};
+
+		ipi_mailbox_rpu0: mailbox@ff990040 {
+			reg = <0x00 0xff990040 0x00 0x20>,
+			      <0x00 0xff990060 0x00 0x20>,
+			      <0x00 0xff990200 0x00 0x20>,
+			      < 0x00 0xff990220 0x00 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x01>;
+		};
+
+		ipi_mailbox_rpu1: mailbox@ff990080 {
+			reg = <0x00 0xff990080 0x00 0x20>,
+			      <0x00 0xff9900a0 0x00 0x20>,
+			      <0x00 0xff990400 0x00 0x20>,
+			      <0x00 0xff990420 0x00 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <0x01>;
+			xlnx,ipi-id = <0x02>;
+		};
 	};
 
 	dcc {
@@ -591,6 +617,30 @@
 		ranges;
 		phandle = <0x57>;
 	};
+
+	remoteproc {
+		compatible = "xlnx,zynqmp-r5fss";
+		xlnx,cluster-mode = <0>;
+
+		r5f-0 {
+			compatible = "xlnx,zynqmp-r5f";
+			power-domains = <0x12 0x7>;
+			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
+					<&rpu0vdev0vring1>, <&rpu0vdev0buffer>;
+			mboxes = <&ipi_mailbox_rpu0 0>, <&ipi_mailbox_rpu0 1>;
+			mbox-names = "tx", "rx";
+		};
+
+		r5f-1 {
+			compatible = "xlnx,zynqmp-r5f";
+			power-domains = <0x12 0x8>;
+			memory-region = <&rproc_1_fw_image>, <&rpu1vdev1vring0>,
+					<&rpu1vdev1vring1>, <&rpu1vdev1buffer>;
+			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
+			mbox-names = "tx", "rx";
+		};
+	};
+
 
 	axi {
 		compatible = "simple-bus";
@@ -2421,6 +2471,54 @@
 	memory@0 {
 		device_type = "memory";
 		reg = <0x00 0x00 0x00 0x7ff00000 0x08 0x00 0x00 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		rproc_0_fw_image: memory@3ed00000 {
+			no-map;
+			reg = <0x0 0x3ed00000 0x0 0x40000>;
+		};
+
+		rpu0vdev0vring0: vdev0vring0@3ed40000 {
+			no-map;
+			reg = <0x00 0x3ed40000 0x00 0x4000>;
+		};
+
+		rpu0vdev0vring1: vdev0vring1@3ed44000 {
+			no-map;
+			reg = <0x00 0x3ed44000 0x00 0x4000>;
+		};
+
+		rpu0vdev0buffer: vdev0buffer@3ed48000 {
+			no-map;
+			compatible = "shared-dma-pool";
+			reg = <0x00 0x3ed48000 0x00 0x100000>;
+		};
+
+		rproc_1_fw_image: memory@3ef00000 {
+			no-map;
+			reg = <0x0 0x3ef00000 0x0 0x40000>;
+		};
+
+		rpu1vdev1vring0: vdev1vring0@3ef40000 {
+			no-map;
+			reg = <0x00 0x3ef40000 0x00 0x4000>;
+		};
+
+		rpu1vdev1vring1: vdev1vring1@3ef44000 {
+			no-map;
+			reg = <0x00 0x3ef44000 0x00 0x4000>;
+		};
+
+		rpu1vdev1buffer: vdev1buffer@3ef48000 {
+			no-map;
+			compatible = "shared-dma-pool";
+			reg = <0x00 0x3ef48000 0x00 0x100000>;
+		};
 	};
 
 	__symbols__ {

--- a/examples/linux/dts/xilinx/zcu102-openamp-split.dts
+++ b/examples/linux/dts/xilinx/zcu102-openamp-split.dts
@@ -385,31 +385,6 @@
 					};
 				};
 
-				uart1-default {
-					phandle = <0x26>;
-
-					mux {
-						groups = "uart1_5_grp";
-						function = "uart1";
-					};
-
-					conf {
-						groups = "uart1_5_grp";
-						slew-rate = <0x01>;
-						power-source = <0x01>;
-					};
-
-					conf-rx {
-						pins = "MIO21";
-						bias-high-impedance;
-					};
-
-					conf-tx {
-						pins = "MIO20";
-						bias-disable;
-					};
-				};
-
 				usb0-default {
 					phandle = <0x28>;
 
@@ -1994,24 +1969,6 @@
 			phandle = <0x99>;
 		};
 
-		serial@ff010000 {
-			u-boot,dm-pre-reloc;
-			compatible = "xlnx,zynqmp-uart\0cdns,uart-r1p12";
-			status = "okay";
-			interrupt-parent = <0x05>;
-			interrupts = <0x00 0x16 0x04>;
-			reg = <0x00 0xff010000 0x00 0x1000>;
-			clock-names = "uart_clk\0pclk";
-			power-domains = <0x12 0x22>;
-			clocks = <0x04 0x39 0x04 0x1f>;
-			pinctrl-names = "default";
-			pinctrl-0 = <0x26>;
-			cts-override;
-			device_type = "serial";
-			port-number = <0x01>;
-			phandle = <0x9a>;
-		};
-
 		usb@ff9d0000 {
 			#address-cells = <0x02>;
 			#size-cells = <0x02>;
@@ -2295,7 +2252,6 @@
 		nvmem0 = "/axi/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
 		rtc0 = "/axi/rtc@ffa60000";
 		serial0 = "/axi/serial@ff000000";
-		serial1 = "/axi/serial@ff010000";
 		serial2 = "/dcc";
 		spi0 = "/axi/spi@ff0f0000";
 		usb0 = "/axi/usb@ff9d0000";
@@ -2559,7 +2515,6 @@
 		pinctrl_i2c1_default = "/firmware/zynqmp-firmware/pinctrl/i2c1-default";
 		pinctrl_i2c1_gpio = "/firmware/zynqmp-firmware/pinctrl/i2c1-gpio";
 		pinctrl_uart0_default = "/firmware/zynqmp-firmware/pinctrl/uart0-default";
-		pinctrl_uart1_default = "/firmware/zynqmp-firmware/pinctrl/uart1-default";
 		pinctrl_usb0_default = "/firmware/zynqmp-firmware/pinctrl/usb0-default";
 		pinctrl_gem3_default = "/firmware/zynqmp-firmware/pinctrl/gem3-default";
 		pinctrl_can1_default = "/firmware/zynqmp-firmware/pinctrl/can1-default";
@@ -2661,7 +2616,6 @@
 		ttc2 = "/axi/timer@ff130000";
 		ttc3 = "/axi/timer@ff140000";
 		uart0 = "/axi/serial@ff000000";
-		uart1 = "/axi/serial@ff010000";
 		usb0 = "/axi/usb@ff9d0000";
 		dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
 		usb1 = "/axi/usb@ff9e0000";


### PR DESCRIPTION
Update zcu102 dts to 2023.2 petalinux release.

This dts also contains remoteproc nodes for xilinx remoteproc driver available in upstream 6.5 kernel.
