### PR TITLE
examples: dts: fix reserved memory nodes for core1 rpmsg

### DIFF
--- a/examples/linux/dts/xilinx/zynqmp-openamp.dtsi
+++ b/examples/linux/dts/xilinx/zynqmp-openamp.dtsi
@@ -32,17 +32,17 @@
 			reg = <0x0 0x3ef00000 0x0 0x40000>;
 		};
 
-		rpu1vdev1vring0: vdev1vring0@3ef40000 {
+		rpu1vdev0vring0: vdev0vring0@3ef40000 {
 			no-map;
 			reg = <0x00 0x3ef40000 0x00 0x4000>;
 		};
 
-		rpu1vdev1vring1: vdev1vring1@3ef44000 {
+		rpu1vdev0vring1: vdev0vring1@3ef44000 {
 			no-map;
 			reg = <0x00 0x3ef44000 0x00 0x4000>;
 		};
 
-		rpu1vdev1buffer: vdev1buffer@3ef48000 {
+		rpu1vdev0buffer: vdev0buffer@3ef48000 {
 			no-map;
 			compatible = "shared-dma-pool";
 			reg = <0x00 0x3ef48000 0x00 0x100000>;
@@ -86,8 +86,8 @@
 		};
 
 		r5f-1 {
-			memory-region = <&rproc_1_fw_image>, <&rpu1vdev1vring0>,
-					<&rpu1vdev1vring1>, <&rpu1vdev1buffer>;
+			memory-region = <&rproc_1_fw_image>, <&rpu1vdev0vring0>,
+					<&rpu1vdev0vring1>, <&rpu1vdev0buffer>;
 			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
 			mbox-names = "tx", "rx";
 		};


### PR DESCRIPTION
Xilinx remoteproc driver expects node name to be vdev0vringx and vdev0buffer. Remoteproc framework will add memory carveouts based on these names. Fix current node names for core1 rpmsg accordingly.