### PR TITLE
dtb: Fix zcu102 bare-metal

### DIFF
--- a/examples/linux/dts/xilinx/zcu102-openamp.dtso
+++ b/examples/linux/dts/xilinx/zcu102-openamp.dtso
@@ -1,7 +1,7 @@
 /* Changes specific to zcu102 but common to mode */
 
-/* include everything from generic zynqmp-openamp overlay */
-#include "zynqmp-openamp.dtso"
+/dts-v1/;
+/plugin/;
 
 /* Plus make these specific zcu102 changes */
 &{/axi} {


### PR DESCRIPTION
This fix is already in the v2023.10 branch but it is needed here on main as well.

A holdover from the dtsi model was getting both mailbox configs in the bare-metal dtb for zcu102.

Fix this by making the zcu102-openamp overlay only disable the serial port and not include the zynqmp-openamp overlay defs.