### PR TITLE
Zynqmp DTS: Update for v6.6 kernel

### DIFF
--- a/examples/linux/dts/xilinx/Makefile
+++ b/examples/linux/dts/xilinx/Makefile
@@ -6,7 +6,7 @@ DTBS += zynqmp-smk-k26-revA.dtb zynqmp-zcu102-rev1.0.dtb
 DTBS += zcu102-xilinx-bm-lockstep.dtb kv260-xilinx-bm-lockstep.dtb
 
 DTBOS := zynqmp-split.dtbo zcu102-openamp.dtbo zynqmp-openamp.dtbo
-DTBOS += zynqmp-sck-kv-g-revB.dtbo xilinx-openamp-for-v6.5.dtbo
+DTBOS += zynqmp-sck-kv-g-revB.dtbo xilinx-openamp-for-v6.x.dtbo
 
 # any file to test we have a valid kernel source dir
 XILINX_DTS_DIR := $(LINUX_SRC_DIR)/arch/arm64/boot/dts/xilinx
@@ -89,13 +89,13 @@ kv260-openamp-split.dtb: \
 
 zcu102-xilinx-bm-lockstep.dtb: \
 	zynqmp-zcu102-rev1.0.dtb \
-	xilinx-openamp-for-v6.5.dtbo \
+	xilinx-openamp-for-v6.x.dtbo \
 	zcu102-openamp.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 kv260-xilinx-bm-lockstep.dtb: \
 	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
-	xilinx-openamp-for-v6.5.dtbo
+	xilinx-openamp-for-v6.x.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 clean:

--- a/examples/linux/dts/xilinx/xilinx-openamp-for-v6.x.dtso
+++ b/examples/linux/dts/xilinx/xilinx-openamp-for-v6.x.dtso
@@ -1,4 +1,14 @@
-/* Applies to all zynqmp boards to configure the IPC & memory for OpenAMP */
+/* Applies to all zynqmp boards to configure the IPC & memory for OpenAMP
+**
+** This configuration is compatible with old bare-metal apps built with
+** petalinux v2023 and before.
+**
+** It uses different IPC interrupt channels
+** It only supports lockstep mode
+**
+** Bare-metal apps that do not use rpmsg (or any other IPI) can use the normal
+** dtbs and thus can support lockstep and split mode.
+*/
 
 /dts-v1/;
 /plugin/;
@@ -58,40 +68,6 @@
 		};
 	};
 
-#if 0
-	zynqmp_ipi {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		ipi_mailbox_rpu0: mailbox@ff990040 {
-			reg = <0x00 0xff990040 0x00 0x20>,
-			      <0x00 0xff990060 0x00 0x20>,
-			      <0x00 0xff990200 0x00 0x20>,
-			      < 0x00 0xff990220 0x00 0x20>;
-			reg-names = "local_request_region",
-				    "local_response_region",
-				    "remote_request_region",
-				    "remote_response_region";
-			#mbox-cells = <0x01>;
-			xlnx,ipi-id = <0x01>;
-		};
-
-		ipi_mailbox_rpu1: mailbox@ff990080 {
-			reg = <0x00 0xff990420 0x00 0x20>,
-			      <0x00 0xff990440 0x00 0x20>,
-			      <0x00 0xff990260 0x00 0x20>,
-			      <0x00 0xff990280 0x00 0x20>;
-			reg-names = "local_request_region",
-				    "local_response_region",
-				    "remote_request_region",
-				    "remote_response_region";
-			#mbox-cells = <0x01>;
-			xlnx,ipi-id = <0x02>;
-		};
-	};
-#endif
-
 	remoteproc: remoteproc {
 		r5f-0 {
 			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
@@ -99,14 +75,5 @@
 			mboxes = <&ipi_mailbox_rpu0 0>, <&ipi_mailbox_rpu0 1>;
 			mbox-names = "tx", "rx";
 		};
-
-#if 0
-		r5f-1 {
-			memory-region = <&rproc_1_fw_image>, <&rpu1vdev1vring0>,
-					<&rpu1vdev1vring1>, <&rpu1vdev1buffer>;
-			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
-			mbox-names = "tx", "rx";
-		};
-#endif
 	};
 };

--- a/examples/linux/dts/xilinx/zynqmp-openamp.dtso
+++ b/examples/linux/dts/xilinx/zynqmp-openamp.dtso
@@ -1,4 +1,7 @@
-/* Applies to all zynqmp boards to configure the IPC & memory for OpenAMP */
+/* Applies to all zynqmp boards to configure the IPC & memory for OpenAMP
+** This configuration is compatible with zephyr rpmsg and other modern uses of
+** rpmsg
+*/
 
 /dts-v1/;
 /plugin/;


### PR DESCRIPTION
No real update was needed for v6.6 but update the names and comments to make things more clear.  Delete the #if 0 stuff in the bare-metal dtso.

Looking ahead this configuration looks compatible and still needed for v6.6 through at least v6.10 (as of v6.10-rc6).