### PR TITLE
legay_apps: test: fix bad array index in  rpmsg-nocopy-echo

### DIFF
--- a/examples/legacy_apps/tests/msg/rpmsg-nocopy-echo.c
+++ b/examples/legacy_apps/tests/msg/rpmsg-nocopy-echo.c
@@ -157,7 +157,7 @@ int app(struct rpmsg_device *rdev, void *priv)
 					LPERROR("Failed to get payload...\r\n");
 					break;
 				}
-				if (tx_msg == buff_list[MAX_NB_TX_BUFF]) {
+				if (tx_msg == buff_list[MAX_NB_TX_BUFF - 1]) {
 					LPERROR("error: got the lost buffer\r\n");
 					break;
 				}


### PR DESCRIPTION
The buff_list contains MAX_NB_TX_BUFF elements. 
The last element is at index (MAX_NB_TX_BUFF - 1).