### PR TITLE
examples: Zephyr: update rpmsg-multi-service readme

### DIFF
--- a/examples/zephyr/rpmsg_multi_services/README.rst
+++ b/examples/zephyr/rpmsg_multi_services/README.rst
@@ -25,6 +25,7 @@ Tested on board:
 * `stm32mp157c_dk2 <https://docs.zephyrproject.org/latest/boards/st/stm32mp157c_dk2/doc/stm32mp157_dk2.html>`_
 * stm32mp157f_dk2 (use stm32mp157c_dk2 for the zephyr build)
 * `kv260_r5        <https://docs.zephyrproject.org/latest/boards/amd/kv260_r5/doc/index.html>`_
+* `imx8mp_evk/mimx8ml8/adsp        <https://docs.zephyrproject.org/latest/boards/nxp/imx8mp_evk/doc/index.html>`_
 
 Building the application
 *************************


### PR DESCRIPTION
Update README file to include NXP i.MX8M Plus board support.