### PR TITLE
legacy_apps: Fix rpc demo dynamic library build

### DIFF
--- a/examples/legacy_apps/examples/rpc_demo/CMakeLists.txt
+++ b/examples/legacy_apps/examples/rpc_demo/CMakeLists.txt
@@ -29,6 +29,7 @@ foreach (_app ${app_list})
 
   if (WITH_SHARED_LIB)
     add_executable (${_app}-shared ${_sources})
+    target_compile_options (${_app}-shared PRIVATE "-fPIC")
     target_link_libraries (${_app}-shared -shared ${OPENAMP_LIB} ${_deps})
     install (TARGETS ${_app}-shared RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif (WITH_SHARED_LIB)


### PR DESCRIPTION
Add the missing -fPIC option for dynamic library generation to fix the following error:

/usr/bin/ld: CMakeFiles/rpc_demod-shared.dir/__/__/system/linux/machine/generic/rsc_table.c.o: relocation R_X86_64_PC32 against symbol `resources' can not be used when making a shared object; recompile with -fPIC