### PR TITLE
legacy_apps: zynqmp_r5 machine: Fix typo in comment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,8 @@ build:
     - libhugetlbfs-dev
     - libsysfs-dev
   # here it would be nice to tell them that the conf.py will be in openamp-docs/conf.py
-  # sphinx:
-  #   configuration: openamp-docs/conf.py
+  sphinx:
+    configuration: openamp-docs/conf.py
   # HOWEVER, if we say this they check right after they do checkout and it does not exist yet
   # As of now they find it well enough right before the build stage
   jobs:

--- a/examples/legacy_apps/machine/zynqmp_r5/zynqmp_r5_a53_rproc.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/zynqmp_r5_a53_rproc.c
@@ -180,7 +180,7 @@ static int zynqmp_r5_a53_proc_notify(struct remoteproc *rproc, uint32_t id)
 }
 
 /* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+ * notification operation and remote processor management operations. */
 const struct remoteproc_ops zynqmp_r5_a53_proc_ops = {
 	.init = zynqmp_r5_a53_proc_init,
 	.remove = zynqmp_r5_a53_proc_remove,


### PR DESCRIPTION
Correct 'managementi' to 'management' in a comment describing remote processor operations.

Signed-off-by: Henry Chaing <n96121210@gs.ncku.edu.tw>