### PR TITLE
legacy apps: update cmake minimum support to 3.16

### DIFF
--- a/examples/legacy_apps/CMakeLists.txt
+++ b/examples/legacy_apps/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_minimum_required (VERSION 3.16)
 
 set (APPS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set (APPS_SHARE_DIR "${CMAKE_CURRENT_BINARY_DIR}/share")


### PR DESCRIPTION
We currently support an old version of CMake (3.0.2) that was released in 2018. Next cmake revisions will support 3.5 as minimum version.

Update the minimum version to 3.16, aligned with the libmetal and the open-amp libraies.

By updating to CMake 3.16 as the minimum version, we can also clean up the following policy add-ons:
- CMP0048 added in CMake v3.0
- CMP0077 added in CMake v3.13