### PR TITLE
examples: fix indentation and comments

### DIFF
--- a/examples/legacy_apps/examples/linux_rpc_demo/linux_rpc_demod.c
+++ b/examples/legacy_apps/examples/linux_rpc_demo/linux_rpc_demod.c
@@ -139,9 +139,7 @@ int rpmsg_handle_read(void *data, struct rpmsg_rpc_svr *rpcs)
 
 	if (rpc_read_req->fd == 0) {
 		bytes_read = MAX_STRING_LEN;
-		/* Perform read from fd for large size since this is a
-		 * STD/I request
-		 */
+		/* Perform read from fd for large size since this is a STD/I request */
 		bytes_read = read(rpc_read_req->fd, rpc_read_resp.buf,
 				  bytes_read);
 	} else {

--- a/examples/legacy_apps/examples/load_fw/platform_info.c
+++ b/examples/legacy_apps/examples/load_fw/platform_info.c
@@ -31,7 +31,7 @@ static struct remoteproc * platform_create_proc(unsigned int cpu_id)
 }
 
 static void app_log_handler(enum metal_log_level level,
-                   const char *format, ...)
+			    const char *format, ...)
 {
 	char msg[1024];
 	va_list args;
@@ -60,25 +60,25 @@ static XIpiPsu IpiInst;
 
 static XStatus IpiConfigure(XIpiPsu *const IpiInstPtr)
 {
-    XStatus Status;
-    XIpiPsu_Config *IpiCfgPtr;
+	XStatus Status;
+	XIpiPsu_Config *IpiCfgPtr;
 
-    /* Look Up the config data */
-    IpiCfgPtr = XIpiPsu_LookupConfig(XPAR_XIPIPSU_0_DEVICE_ID);
-    if (NULL == IpiCfgPtr) {
-        Status = XST_FAILURE;
-        LPERROR("%s ERROR in getting CfgPtr\n", __func__);
-        return Status;
-    }
+	/* Look Up the config data */
+	IpiCfgPtr = XIpiPsu_LookupConfig(XPAR_XIPIPSU_0_DEVICE_ID);
+	if (NULL == IpiCfgPtr) {
+		Status = XST_FAILURE;
+		LPERROR("%s ERROR in getting CfgPtr\n", __func__);
+		return Status;
+	}
 
-    /* Init with the Cfg Data */
-    Status = XIpiPsu_CfgInitialize(IpiInstPtr, IpiCfgPtr,
-                       IpiCfgPtr->BaseAddress);
-    if (XST_SUCCESS != Status) {
-        LPERROR("%s ERROR #%d in configuring IPI\n", __func__, Status);
-        return Status;
-    }
-    return Status;
+	/* Init with the Cfg Data */
+	Status = XIpiPsu_CfgInitialize(IpiInstPtr, IpiCfgPtr,
+			IpiCfgPtr->BaseAddress);
+	if (XST_SUCCESS != Status) {
+		LPERROR("%s ERROR #%d in configuring IPI\n", __func__, Status);
+		return Status;
+	}
+	return Status;
 }
 
 struct remoteproc * app_init(unsigned int cpu_id){

--- a/examples/legacy_apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
+++ b/examples/legacy_apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
@@ -87,7 +87,8 @@ static void *apu_rproc_mmap(struct remoteproc *rproc,
 		return NULL;
 	}
 
-	/* This code only runs on the R5, which has a flat memory
+	/*
+	 * This code only runs on the R5, which has a flat memory
 	 * space. Therefore, we use the same value for the physical
 	 * and virtual addresses we pass in to metal_io_init().
 	 */
@@ -112,7 +113,7 @@ static int apu_rproc_start(struct remoteproc *rproc)
 		LPRINTF("%s: Failed to start APU 0x%x, ret=0x%x\n\r",
 			__func__, priv->cpu_id, ret);
 		return -1;
-	} 
+	}
 	return 0;
 }
 
@@ -164,10 +165,10 @@ static int apu_rproc_shutdown(struct remoteproc *rproc)
 }
 
 const struct remoteproc_ops zynqmp_apu_rproc_ops = {
-    .init = apu_rproc_init,
-    .remove = apu_rproc_remove,
-    .start = apu_rproc_start,
-    .stop = apu_rproc_stop,
-    .shutdown = apu_rproc_shutdown,
-    .mmap = apu_rproc_mmap,
+	.init = apu_rproc_init,
+	.remove = apu_rproc_remove,
+	.start = apu_rproc_start,
+	.stop = apu_rproc_stop,
+	.shutdown = apu_rproc_shutdown,
+	.mmap = apu_rproc_mmap,
 };

--- a/examples/legacy_apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
+++ b/examples/legacy_apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
@@ -100,10 +100,11 @@ static void *rpu_rproc_mmap(struct remoteproc *rproc,
 		return NULL;
 	}
 
-        /* This code only runs on the R5, which has a flat memory
-         * space. Therefore, we use the same value for the physical
-         * and virtual addresses we pass in to metal_io_init().
-         */
+	/*
+	 * This code only runs on the R5, which has a flat memory
+	 * space. Therefore, we use the same value for the physical
+	 * and virtual addresses we pass in to metal_io_init().
+	 */
 	metal_io_init(*io, (void *)mem->pa, &mem->pa, size,
 		      sizeof(metal_phys_addr_t)<<3, attribute, NULL);
 	remoteproc_init_mem(mem, NULL, lpa, lda, size, *io);
@@ -189,10 +190,10 @@ static int rpu_rproc_shutdown(struct remoteproc *rproc)
 }
 
 const struct remoteproc_ops zynqmp_rpu_rproc_ops = {
-    .init = rpu_rproc_init,
-    .remove = rpu_rproc_remove,
-    .start = rpu_rproc_start,
-    .stop = rpu_rproc_stop,
-    .shutdown = rpu_rproc_shutdown,
-    .mmap = rpu_rproc_mmap,
+	.init = rpu_rproc_init,
+	.remove = rpu_rproc_remove,
+	.start = rpu_rproc_start,
+	.stop = rpu_rproc_stop,
+	.shutdown = rpu_rproc_shutdown,
+	.mmap = rpu_rproc_mmap,
 };

--- a/examples/legacy_apps/examples/rpc_demo/rpc_demod.c
+++ b/examples/legacy_apps/examples/rpc_demo/rpc_demod.c
@@ -247,7 +247,8 @@ static int rpmsg_endpoint_cb(struct rpmsg_endpoint *ept, void *data, size_t len,
 		return RPMSG_SUCCESS;
 	}
 
-	/* In case the shared memory is device memory
+	/*
+	 * In case the shared memory is device memory
 	 * E.g. For now, we only use UIO device memory in Linux.
 	 */
 	if (len > RPC_BUFF_SIZE)

--- a/examples/legacy_apps/machine/microblaze_generic/platform_info.c
+++ b/examples/legacy_apps/machine/microblaze_generic/platform_info.c
@@ -84,7 +84,7 @@ static struct remoteproc *platform_create_proc(int proc_index, int rsc_index)
 		remoteproc_remove(&rproc_inst);
 		return NULL;
 	}
-    /* dbg("%d:%s rsc_table= %p\r\n", __LINE__, __func__, rsc_table); */
+	/* dbg("%d:%s rsc_table= %p\r\n", __LINE__, __func__, rsc_table); */
 	xil_printf("Initialize remoteproc successfully.\r\n");
 
 	return &rproc_inst;

--- a/examples/legacy_apps/machine/zynq7/platform_info.c
+++ b/examples/legacy_apps/machine/zynq7/platform_info.c
@@ -42,8 +42,10 @@
 
 #define _rproc_wait() asm volatile("wfi")
 
-/* processor operations for hil_proc for A9. It defines
- * notification operation and remote processor management. */
+/*
+ * processor operations for hil_proc for A9. It defines
+ * notification operation and remote processor management.
+ */
 extern const struct remoteproc_ops zynq_a9_proc_ops;
 static metal_phys_addr_t scugic_phys_addr = SCUGIC_DIST_BASE;
 struct metal_device scugic_device = {
@@ -198,16 +200,12 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 
 	xil_printf("initializing rpmsg vdev\r\n");
 	if (role == VIRTIO_DEV_DRIVER) {
-		/* Only RPMsg virtio driver needs to initialize the
-		 * shared buffers pool
-		 */
+		/* Only RPMsg virtio driver needs to initialize the shared buffers pool */
 		rpmsg_virtio_init_shm_pool(&shpool, shbuf,
 					   (SHARED_MEM_SIZE -
 					    SHARED_BUF_OFFSET));
 
-		/* RPMsg virtio device can set shared buffers pool
-		 * argument to NULL
-		 */
+		/* RPMsg virtio device can set shared buffers pool argument to NULL */
 		ret =  rpmsg_init_vdev(rpmsg_vdev, vdev, ns_bind_cb,
 				       shbuf_io, &shpool);
 	} else {

--- a/examples/legacy_apps/machine/zynq7/platform_info_remoteproc_master.c
+++ b/examples/legacy_apps/machine/zynq7/platform_info_remoteproc_master.c
@@ -13,7 +13,7 @@
  * DESCRIPTION
  *
  *       This file implements APIs to get platform specific
- *       information for OpenAMP. 
+ *       information for OpenAMP.
  *
  **************************************************************************/
 
@@ -21,8 +21,10 @@
 #include <openamp/hil.h>
 #include <openamp/firmware.h>
 
-/* Reference implementation that show cases platform_get_cpu_info and 
- platform_get_for_firmware API implementation for Bare metal environment */
+/*
+ * Reference implementation that show cases platform_get_cpu_info and
+ * platform_get_for_firmware API implementation for Bare metal environment
+ */
 
 extern struct hil_platform_ops zynq_a9_proc_ops;
 
@@ -72,61 +74,62 @@ extern struct hil_platform_ops zynq_a9_proc_ops;
  *   Host node, however in baremetal host and linux remote case the linux
  *   rpmsg bus driver behaves as host so the rpmsg driver on linux side still needs
  *   channel info. This information is not required by the hosts for baremetal
- *   remotes. 
- *
+ *   remotes.
  */
-struct hil_proc proc_table []=
+struct hil_proc proc_table[]=
 {
-    {
-        /* CPU ID of remote */
-        REMOTE_CPU_ID,
+	{
+		/* CPU ID of remote */
+		REMOTE_CPU_ID,
 
-        /* Shared memory info - Last field is not used currently */
-        {
-            SHM_ADDR, SHM_SIZE, 0x00
-        },
+		/* Shared memory info - Last field is not used currently */
+		{
+			SHM_ADDR, SHM_SIZE, 0x00
+		},
 
-        /* VirtIO device info */
-        {
-            0, 0, 0,
-            {
-                {
-                    /* Provide vring interrupts info here. Other fields are obtained
-                     * from the rsc table so leave them empty.
-                     */
-                    NULL, NULL, 0, 0,
-                    {
-                        VRING0_IPI_VECT,0x1006,1
-                    }
-                },
-                {
-                    NULL, NULL, 0, 0,
-                    {
-                        VRING1_IPI_VECT,0x1006,1
-                    }
-                }
-            }
-        },
+		/* VirtIO device info */
+		{
+			0, 0, 0,
+			{
+				{
+				/*
+				 * Provide vring interrupts info here. Other fields are obtained
+				 * from the rsc table so leave them empty.
+				 */
+					NULL, NULL, 0, 0,
+					{
+						VRING0_IPI_VECT,0x1006,1
+					}
+				},
+				{
+					NULL, NULL, 0, 0,
+					{
+						VRING1_IPI_VECT,0x1006,1
+					}
+				}
+			}
+		},
 
-        /* Number of RPMSG channels */
-        1,
+		/* Number of RPMSG channels */
+		1,
 
-        /* RPMSG channel info - Only channel name is expected currently */
-        {
-            {"rpmsg-openamp-demo-channel"}
-        },
+		/* RPMSG channel info - Only channel name is expected currently */
+		{
+			{"rpmsg-openamp-demo-channel"}
+		},
 
-        /* HIL platform ops table. */
-        &zynq_a9_proc_ops,
+		/* HIL platform ops table. */
+		&zynq_a9_proc_ops,
 
-        /* Next three fields are for future use only */
-        0,
-        0,
-        NULL
-    }
+		/* Next three fields are for future use only */
+		0,
+		0,
+		NULL
+	}
 };
 
-/* Start and end addresses of firmware image for remotes. These are defined in the
+/*
+ * Start and end addresses of firmware image for remotes. These are defined in the
  * object files that are obtained by converting the remote ELF Image into object
  * files. These symbols are not used for remotes.
  */

--- a/examples/legacy_apps/machine/zynq7/zynq_a9_rproc.c
+++ b/examples/legacy_apps/machine/zynq7/zynq_a9_rproc.c
@@ -154,8 +154,10 @@ static int zynq_a9_proc_notify(struct remoteproc *rproc, uint32_t id)
 	return 0;
 }
 
-/* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+/*
+ * processor operations from r5 to a53. It defines
+ * notification operation and remote processor management operations.
+ */
 const struct remoteproc_ops zynq_a9_proc_ops = {
 	.init = zynq_a9_proc_init,
 	.remove = zynq_a9_proc_remove,

--- a/examples/legacy_apps/machine/zynqmp/platform_info.c
+++ b/examples/legacy_apps/machine/zynqmp/platform_info.c
@@ -32,10 +32,9 @@
 #include <sys/un.h>
 #include "platform_info.h"
 
-#define RPU_CPU_ID          0 /* RPU remote CPU Index. We only talk to
-			       * one CPU in the example. We set the CPU
-			       * index to 0.
-			       */
+/* RPU remote CPU Index. We only talk to one CPU in the example. We set the CPU index to 0. */
+#define RPU_CPU_ID          0
+
 #ifdef VERSAL_NET
 #ifndef IPI_CHN_BITMASK
 #define IPI_CHN_BITMASK	    0x08
@@ -45,8 +44,7 @@
 #endif /* !IPI_DEV_NAME */
 #elif defined(versal)
 #ifndef IPI_CHN_BITMASK
-#define IPI_CHN_BITMASK     0x08 /* IPI channel bit mask for IPI
-					* from/to RPU0 */
+#define IPI_CHN_BITMASK     0x08 /* IPI channel bit mask for IPI  from/to RPU0 */
 #endif /* !IPI_CHN_BITMASK */
 #ifndef IPI_DEV_NAME
 #define IPI_DEV_NAME        "ff360000.ipi" /* IPI device name */
@@ -59,12 +57,15 @@
 #define IPI_DEV_NAME	    "ff340000.ipi"
 #endif /* !IPI_DEV_NAME */
 #endif /* versal */
-#define DEV_BUS_NAME        "platform" /* device bus name. "platform" bus
-                                        * is used in Linux kernel for generic
-					* devices */
-/* libmetal devices names used in the examples.
+
+/* device bus name. "platform" bus  is used in Linux kernel for generic devices	*/
+#define DEV_BUS_NAME        "platform"
+
+/*
+ * libmetal devices names used in the examples.
  * They are platform devices, you find them in Linux sysfs
- * sys/bus/platform/devices */
+ * sys/bus/platform/devices
+ */
 #ifndef SHM_DEV_NAME
 #define SHM_DEV_NAME        "3ed20000.shm" /* shared device name */
 #endif /* SHM_DEV_NAME */
@@ -110,8 +111,10 @@ extern void cleanup_system(void);
 #define _rproc_wait() metal_cpu_yield()
 
 
-/* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+/*
+ * processor operations from r5 to a53. It defines
+ * notification operation and remote processor management operations.
+ */
 extern const struct remoteproc_ops zynqmp_linux_r5_proc_ops;
 
 /* RPMsg virtio shared buffer pool */

--- a/examples/legacy_apps/machine/zynqmp/zynqmp_linux_r5_proc.c
+++ b/examples/legacy_apps/machine/zynqmp/zynqmp_linux_r5_proc.c
@@ -229,8 +229,10 @@ static int zynqmp_linux_r5_proc_notify(struct remoteproc *rproc, uint32_t id)
 	return 0;
 }
 
-/* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+/*
+ * processor operations from r5 to a53. It defines
+ * notification operation and remote processor managementi operations.
+ */
 const struct remoteproc_ops zynqmp_linux_r5_proc_ops = {
 	.init = zynqmp_linux_r5_proc_init,
 	.remove = zynqmp_linux_r5_proc_remove,

--- a/examples/legacy_apps/machine/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/platform_info.c
@@ -58,8 +58,7 @@
 #define _rproc_wait() asm volatile("wfi")
 #endif /* !RPMSG_NO_IPI */
 
-/* Polling information used by remoteproc operations.
- */
+/* Polling information used by remoteproc operations. */
 static metal_phys_addr_t poll_phys_addr = POLL_BASE_ADDR;
 struct metal_device kick_device = {
 	.name = "poll_dev",
@@ -97,8 +96,10 @@ static struct remoteproc rproc_inst;
 extern int init_system(void);
 extern void cleanup_system(void);
 
-/* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+/*
+ * processor operations from r5 to a53. It defines
+ * notification operation and remote processor management operations.
+ */
 extern const struct remoteproc_ops zynqmp_r5_a53_proc_ops;
 
 /* RPMsg virtio shared buffer pool */

--- a/examples/legacy_apps/machine/zynqmp_r5/zynqmp_r5_a53_rproc.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/zynqmp_r5_a53_rproc.c
@@ -13,7 +13,7 @@
  *
  * DESCRIPTION
  *
- *       This file define Xilinx ZynqMP R5 to A53 platform specific 
+ *       This file define Xilinx ZynqMP R5 to A53 platform specific
  *       remoteproc implementation.
  *
  **************************************************************************/
@@ -179,8 +179,10 @@ static int zynqmp_r5_a53_proc_notify(struct remoteproc *rproc, uint32_t id)
 	return 0;
 }
 
-/* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+/*
+ * processor operations from r5 to a53. It defines
+ * notification operation and remote processor management operations.
+ */
 const struct remoteproc_ops zynqmp_r5_a53_proc_ops = {
 	.init = zynqmp_r5_a53_proc_init,
 	.remove = zynqmp_r5_a53_proc_remove,

--- a/examples/legacy_apps/system/generic/machine/zynq7/helper.c
+++ b/examples/legacy_apps/system/generic/machine/zynq7/helper.c
@@ -51,7 +51,8 @@ static int app_gic_initialize(void)
 			(Xil_ExceptionHandler)XScuGic_InterruptHandler,
 			&xInterruptController);
 
-	/* Disable the interrupt before enabling exception to avoid interrupts
+	/*
+	 * Disable the interrupt before enabling exception to avoid interrupts
 	 * received before exception is enabled.
 	 */
 	XScuGic_Disable(&xInterruptController, SGI_NOTIFICATION);

--- a/examples/legacy_apps/system/generic/machine/zynqmp_r5/helper.c
+++ b/examples/legacy_apps/system/generic/machine/zynqmp_r5/helper.c
@@ -67,7 +67,8 @@ static int app_gic_initialize(void)
 			(Xil_ExceptionHandler)XScuGic_InterruptHandler,
 			&xInterruptController);
 
-	/* Disable the interrupt before enabling exception to avoid interrupts
+	/*
+	 * Disable the interrupt before enabling exception to avoid interrupts
 	 * received before exception is enabled.
 	 */
 	XScuGic_Disable(&xInterruptController, IPI_IRQ_VECT_ID);

--- a/examples/legacy_apps/system/linux/machine/generic/platform_info.c
+++ b/examples/legacy_apps/system/linux/machine/generic/platform_info.c
@@ -213,8 +213,7 @@ static int event_open(const char *descr)
 	}
 
 	if (!is_sk_unix_server(descr)) {
-		/* UNIX client.  Retry to connect a few times to give the peer
-		 *  a chance to setup.  */
+		/* UNIX client. Retry to connect a few times to give the peer a chance to setup. */
 		for (i = 0; i < 100 && fd == -1; i++) {
 			fd = sk_unix_client(descr);
 			if (fd == -1)
@@ -363,8 +362,10 @@ static int linux_proc_notify(struct remoteproc *rproc, uint32_t id)
 	return 0;
 }
 
-/* processor operations from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
+/*
+ * processor operations from r5 to a53. It defines
+ * notification operation and remote processor management operations.
+ */
 static const struct remoteproc_ops linux_proc_ops = {
 	.init = linux_proc_init,
 	.remove = linux_proc_remove,

--- a/examples/linux/common/common.c
+++ b/examples/linux/common/common.c
@@ -25,8 +25,8 @@ int app_rpmsg_create_ept(int rpfd, struct rpmsg_endpoint_info *eptinfo)
 }
 
 char *get_rpmsg_ept_dev_name(const char *rpmsg_char_name,
-                             const char *ept_name,
-                             char *ept_dev_name)
+			     const char *ept_name,
+			     char *ept_dev_name)
 {
 	char sys_rpmsg_ept_name_path[64];
 	char svc_name[64];

--- a/examples/linux/rpmsg-proxy-app/proxy_app.c
+++ b/examples/linux/rpmsg-proxy-app/proxy_app.c
@@ -81,8 +81,7 @@ int handle_read(struct _sys_rpc *rpc)
 	char *buff = proxy->rpc_response->sys_call_args.data;
 
 	if (rpc->sys_call_args.int_field1 == 0)
-		/* Perform read from fd for large size since this is a
-		STD/I request */
+		/* Perform read from fd for large size since this is a STD/I request */
 		bytes_read = read(rpc->sys_call_args.int_field1, buff, 512);
 	else
 		/* Perform read from fd */
@@ -309,9 +308,9 @@ int main(int argc, char *argv[])
 
 	/* RPC service starts */
 	printf("\r\nHost>RPC service started !!\r\n");
-	/* Send init message to remote.
-	 * This is required otherwise, remote doesn't know the host
-	 * RPMsg endpoint
+	/*
+	 * Send init message to remote.
+	 * This is required otherwise, remote doesn't know the host RPMsg endpoint
 	 */
 	ret = write(proxy->rpmsg_proxy_fd, RPMG_INIT_MSG,
 		    sizeof(RPMG_INIT_MSG));


### PR DESCRIPTION
Replace spaces with tabulations and update the formatting of some comments.