### PR TITLE
examples: dts: xlnx: update dtso for remoteproc nodes

### DIFF
--- a/examples/linux/dts/xilinx/Makefile
+++ b/examples/linux/dts/xilinx/Makefile
@@ -5,7 +5,7 @@ DTBS += kv260-openamp-lockstep.dtb kv260-openamp-split.dtb
 DTBS += zynqmp-smk-k26-revA.dtb zynqmp-zcu102-rev1.0.dtb
 DTBS += zcu102-xilinx-bm-lockstep.dtb kv260-xilinx-bm-lockstep.dtb
 
-DTBOS := zynqmp-split.dtbo zcu102-openamp.dtbo zynqmp-openamp.dtbo
+DTBOS := zynqmp-lockstep.dtbo zcu102-openamp.dtbo zynqmp-openamp.dtbo
 DTBOS += zynqmp-sck-kv-g-revB.dtbo xilinx-openamp-for-v6.x.dtbo
 
 # any file to test we have a valid kernel source dir
@@ -66,25 +66,25 @@ zynqmp-sck-kv-g-revB.dtso: $(XILINX_DTS_DIR)/zynqmp-sck-kv-g-revB.dtso
 zcu102-openamp-lockstep.dtb: \
 	zynqmp-zcu102-rev1.0.dtb \
 	zynqmp-openamp.dtbo \
-	zcu102-openamp.dtbo
+	zcu102-openamp.dtbo \
+	zynqmp-lockstep.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 zcu102-openamp-split.dtb: \
 	zynqmp-zcu102-rev1.0.dtb \
 	zynqmp-openamp.dtbo \
-	zcu102-openamp.dtbo \
-	zynqmp-split.dtbo
+	zcu102-openamp.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 kv260-openamp-lockstep.dtb: \
 	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
-	zynqmp-openamp.dtbo
+	zynqmp-openamp.dtbo \
+	zynqmp-lockstep.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 kv260-openamp-split.dtb: \
 	zynqmp-smk-k26-revA.dtb zynqmp-sck-kv-g-revB.dtbo \
-	zynqmp-openamp.dtbo \
-	zynqmp-split.dtbo
+	zynqmp-openamp.dtbo
 	fdtoverlay -o $@ -i $(filter-out .linux-src-check,$^)
 
 zcu102-xilinx-bm-lockstep.dtb: \

--- a/examples/linux/dts/xilinx/xilinx-openamp-for-v6.x.dtso
+++ b/examples/linux/dts/xilinx/xilinx-openamp-for-v6.x.dtso
@@ -68,7 +68,7 @@
 		};
 	};
 
-	remoteproc: remoteproc {
+	remoteproc@ffe00000 {
 		r5f@0 {
 			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
 					<&rpu0vdev0vring1>, <&rpu0vdev0buffer>;

--- a/examples/linux/dts/xilinx/zynqmp-lockstep.dtso
+++ b/examples/linux/dts/xilinx/zynqmp-lockstep.dtso
@@ -3,7 +3,10 @@
 /dts-v1/;
 /plugin/;
 
-&remoteproc {
-	xlnx,cluster-mode = <0>;
+&rproc_lockstep {
+	status = "okay";
 };
 
+&rproc_split {
+	status = "disabled";
+};

--- a/examples/linux/dts/xilinx/zynqmp-openamp.dtso
+++ b/examples/linux/dts/xilinx/zynqmp-openamp.dtso
@@ -58,7 +58,7 @@
 		};
 	};
 
-	zynqmp_ipi {
+	zynqmp-ipi {
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -67,7 +67,7 @@
 			reg = <0x00 0xff990040 0x00 0x20>,
 			      <0x00 0xff990060 0x00 0x20>,
 			      <0x00 0xff990200 0x00 0x20>,
-			      < 0x00 0xff990220 0x00 0x20>;
+			      <0x00 0xff990220 0x00 0x20>;
 			reg-names = "local_request_region",
 				    "local_response_region",
 				    "remote_request_region",
@@ -90,7 +90,25 @@
 		};
 	};
 
-	remoteproc: remoteproc {
+	rproc_lockstep: remoteproc {
+		status = "disabled";
+		r5f@0 {
+			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
+					<&rpu0vdev0vring1>, <&rpu0vdev0buffer>;
+			mboxes = <&ipi_mailbox_rpu0 0>, <&ipi_mailbox_rpu0 1>;
+			mbox-names = "tx", "rx";
+		};
+
+		r5f@1 {
+			memory-region = <&rproc_1_fw_image>, <&rpu1vdev0vring0>,
+					<&rpu1vdev0vring1>, <&rpu1vdev0buffer>;
+			mboxes = <&ipi_mailbox_rpu1 0>, <&ipi_mailbox_rpu1 1>;
+			mbox-names = "tx", "rx";
+		};
+	};
+
+	rproc_split: remoteproc-split {
+		status = "okay";
 		r5f@0 {
 			memory-region = <&rproc_0_fw_image>, <&rpu0vdev0vring0>,
 					<&rpu0vdev0vring1>, <&rpu0vdev0buffer>;


### PR DESCRIPTION
Use new remoteproc nodes introduced in 6.12 kernel.