### PR TITLE
Amd june30 recovery update

### DIFF
--- a/examples/legacy_apps/machine/zynqmp_r5/helper.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/helper.c
@@ -75,6 +75,12 @@ int init_system(void)
 	int ret;
 	const struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
 
+	/*
+	 * Ensure resource table resource is set up before any attempts
+	 * are made to cache the table.
+	 */
+	get_resource_table(0, &ret);
+
 	circ.c_buf = get_rsc_trace_info(&circ.c_len);
 	if (circ.c_buf && circ.c_len) {
 		metal_param.log_handler = rsc_trace_logger;
@@ -101,6 +107,7 @@ int init_system(void)
 void cleanup_system(void)
 {
 	metal_finish();
+	free_resource_table();
 
 	Xil_DCacheDisable();
 	Xil_ICacheDisable();

--- a/examples/legacy_apps/machine/zynqmp_r5/linker_large_text.ld
+++ b/examples/legacy_apps/machine/zynqmp_r5/linker_large_text.ld
@@ -39,7 +39,16 @@ SECTIONS
    *(.boot)
 } > psu_r5_tcm_ram_0_S_AXI_BASEADDR
 
-.text : {
+/*
+ * This section must be at the start of Shared memory (here DDR)
+ * between APU and RPU. This is special shared memory to store firmware
+ * text/data.
+ */
+.resource_table_metadata @RSC_TABLE@ : {
+	KEEP(*(.resource_table_metadata))
+} > psu_ddr_S_AXI_BASEADDR
+
+.text  @RSC_TABLE@ + 0x100 : {
    *(.text)
    *(.text.*)
    *(.gnu.linkonce.t.*)
@@ -291,7 +300,7 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    __undef_stack = .;
 } > psu_r5_tcm_ram_0_S_AXI_BASEADDR
 
-.resource_table _rsc_table : {
+.resource_table  @RSC_TABLE@ + 0x200 : {
 	. = ALIGN(4);
 	*(.resource_table)
 }

--- a/examples/legacy_apps/machine/zynqmp_r5/linker_remote.ld
+++ b/examples/legacy_apps/machine/zynqmp_r5/linker_remote.ld
@@ -39,7 +39,16 @@ SECTIONS
    *(.boot)
 } > psu_r5_tcm_ram_0_S_AXI_BASEADDR
 
-.text : {
+/*
+ * This section must be at the start of Shared memory (here DDR)
+ * between APU and RPU. This is special shared memory to store firmware
+ * text/data.
+ */
+.resource_table_metadata @RSC_TABLE@ : {
+	KEEP(*(.resource_table_metadata))
+} > psu_ddr_S_AXI_BASEADDR
+
+.text @RSC_TABLE@ + 0x100 : {
    *(.text)
    *(.text.*)
    *(.gnu.linkonce.t.*)
@@ -291,7 +300,7 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    __undef_stack = .;
 } > psu_r5_tcm_ram_0_S_AXI_BASEADDR
 
-.resource_table _rsc_table : {
+.resource_table @RSC_TABLE@ + 0x200 : {
 	. = ALIGN(4);
 	*(.resource_table)
 }

--- a/examples/legacy_apps/machine/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/platform_info.c
@@ -204,6 +204,8 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 	struct metal_io_region *shbuf_io;
 	int ret;
 
+	restore_initial_rsc_table();
+
 	rpmsg_vdev = metal_allocate_memory(sizeof(*rpmsg_vdev));
 	if (!rpmsg_vdev)
 		return NULL;

--- a/examples/legacy_apps/machine/zynqmp_r5/rsc_table.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/rsc_table.c
@@ -17,7 +17,11 @@
 /* Place resource table in special ELF section */
 #define __section_t(S)          __attribute__((__section__(#S)))
 #define __resource              __section_t(.resource_table)
+#define __resource_metadata     __section_t(.resource_table_metadata)
 
+#define RSC_TBL_XLNX_MAGIC	((uint32_t)'x' << 24 | (uint32_t)'a' << 16 | \
+				 (uint32_t)'m' << 8 | (uint32_t)'p')
+ 
 #define RPMSG_VDEV_DFEATURES        (1 << VIRTIO_RPMSG_F_NS)
 
 /* VirtIO rpmsg device id */
@@ -36,6 +40,14 @@
 #define NUM_TABLE_ENTRIES           1
 
 static struct remote_resource_table *initial_resources;
+
+struct remote_resource_table_metadata __resource_metadata resources_metadata = {
+	.version = 1,
+	.magic_num = RSC_TBL_XLNX_MAGIC,
+	.comp_magic_num = (~RSC_TBL_XLNX_MAGIC),
+	.rsc_tbl_size = sizeof(resources),
+	.rsc_tbl = (uintptr_t)&resources
+};
 
 struct remote_resource_table __resource resources = {
 	/* Version */

--- a/examples/legacy_apps/machine/zynqmp_r5/rsc_table.c
+++ b/examples/legacy_apps/machine/zynqmp_r5/rsc_table.c
@@ -35,6 +35,8 @@
 
 #define NUM_TABLE_ENTRIES           1
 
+static struct remote_resource_table *initial_resources;
+
 struct remote_resource_table __resource resources = {
 	/* Version */
 	1,
@@ -64,6 +66,23 @@ void *get_resource_table (int rsc_id, int *len)
 {
 	(void) rsc_id;
 	*len = sizeof(resources);
+	/* make copy of resources to restore later */
+	if (!initial_resources) {
+		initial_resources = (struct remote_resource_table *)malloc(*len);
+		memcpy(initial_resources, &resources, *len);
+	}
+
 	return &resources;
 }
 
+void free_resource_table (void)
+{
+	if (initial_resources)
+		free(initial_resources);
+}
+
+void restore_initial_rsc_table (void)
+{
+	if (initial_resources)
+		memcpy(&resources, initial_resources, sizeof(resources));
+}

--- a/examples/legacy_apps/machine/zynqmp_r5/rsc_table.h
+++ b/examples/legacy_apps/machine/zynqmp_r5/rsc_table.h
@@ -36,6 +36,14 @@ struct remote_resource_table {
 	struct fw_rsc_vdev_vring rpmsg_vring1;
 }__attribute__((packed, aligned(0x100)));
 
+struct remote_resource_table_metadata {
+	const int version;
+	const u32 magic_num;
+	const u32 comp_magic_num;
+	const u32 rsc_tbl_size;
+	const uintptr_t rsc_tbl;
+}__attribute__((packed));
+
 void *get_resource_table (int rsc_id, int *len);
 void free_resource_table (void);
 void restore_initial_rsc_table (void);

--- a/examples/legacy_apps/machine/zynqmp_r5/rsc_table.h
+++ b/examples/legacy_apps/machine/zynqmp_r5/rsc_table.h
@@ -37,6 +37,8 @@ struct remote_resource_table {
 }__attribute__((packed, aligned(0x100)));
 
 void *get_resource_table (int rsc_id, int *len);
+void free_resource_table (void);
+void restore_initial_rsc_table (void);
 
 #if defined __cplusplus
 }


### PR DESCRIPTION
This PR adds support in the AMD RPU Legacy OpenAMP so that the RPU can have IPC reconnected if host has an uncontrolled reboot.
CC @tnmysh 