### PR TITLE
examples: legacy_apps: Fix add default routines for suspend/resume

### DIFF
--- a/examples/legacy_apps/system/linux/machine/generic/platform_info.c
+++ b/examples/legacy_apps/system/linux/machine/generic/platform_info.c
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include "rsc_table.h"
+#include "suspend.h"
 
 #define IPI_CHAN_NUMS 2
 #define IPI_CHAN_SEND 0


### PR DESCRIPTION
Fix following build warning introduced in PR #76:

system/linux/machine/generic/platform_info.c:546:3: warning: implicit declaration of function ‘system_suspend’ [-Wimplicit-function-declaration]
  546 |   system_suspend();
      |   ^~~~~~~~~~~~~~
      