### PR TITLE
AMD: add libmetal demo

### DIFF
--- a/examples/libmetal/CMakeLists.txt
+++ b/examples/libmetal/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.16)
+project (libmetal_apps C)
+
+set (APPS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set (APPS_SHARE_DIR "${CMAKE_CURRENT_BINARY_DIR}/share")
+
+list (APPEND CMAKE_MODULE_PATH
+  "${APPS_ROOT_DIR}../legacy_apps/cmake/"
+  "${APPS_ROOT_DIR}../legacy_apps/cmake/modules"
+  "${APPS_ROOT_DIR}/../legacy_apps/cmake/platforms")
+include ("${APPS_ROOT_DIR}/../legacy_apps/cmake/collect.cmake")
+
+add_subdirectory(demos)
+add_subdirectory(machine)

--- a/examples/libmetal/README.md
+++ b/examples/libmetal/README.md
@@ -1,0 +1,74 @@
+# Libmetal Sample Applications
+
+## Overview
+The `examples/libmetal` tree hosts the libmetal reference demos that exercise
+shared memory, inter-processor interrupts, and atomics. The application logic is
+lifted from the upstream libmetal repository so the OpenAMP System Reference
+contains a one-stop showcase for both Linux userspace and bare-metal/RTOS
+environments. Every demo is split into a *host* role (typically Linux) and a
+*remote* role (an auxiliary core or MCU).
+
+## Directory Layout
+- `demos/<demo>/<role>` – vendor-neutral demo sources. They only depend on the
+  thin platform APIs declared in `machine/<role>/<machine>/common.h`, so they
+  can be reused on any SoC once that layer is implemented.
+- `machine/host/<machine>` – platform glue for the host role. It maps the shared
+  memory window, programs the interrupt controller, and provides helper
+  utilities such as timers or logging hooks.
+- `machine/remote/<machine>` – platform glue for the remote role. It sets up the
+  local run-time (bare metal or RTOS), exports the same helpers as the host
+  layer, and links in board support libraries.
+- `toolchain_file` – example CMake toolchain snippet that injects platform
+  macros (e.g. `-DPLATFORM_ZYNQMP`) so the machine layer can pick the correct
+  peripheral map.
+
+## AMD Reference Port
+The repository currently ships one working port:
+
+- `machine/host/amd_linux_userspace` targets AMD Zynq UltraScale+, Versal, and
+  Versal Net devices. It assumes Linux exposes the shared memory, IPI, and TTC
+  peripherals through userspace drivers (UIO or misc devices).
+- `machine/remote/amd_rpu` targets the matching Cortex-R5 RPU running on
+  bare-metal or FreeRTOS. It links against the AMD BSP libraries listed in
+  `build_deps.cmake` and uses the same helpers that the upstream libmetal demo
+  expects.
+
+Although these directories carry AMD-specific defaults (device names,
+interrupt masks, linker script, etc.), the core demos under `demos/` remain
+unchanged from the upstream project.
+
+## Porting to Other Vendors
+To reuse the demos on a different SoC or operating system:
+
+1. **Create a host machine module.** Copy
+   `machine/host/amd_linux_userspace` as a starting point, rename the directory
+   (e.g. `machine/host/acme_linux_userspace`), and update:
+   - `common.h` with your device identifiers (shared-memory device name, IPI
+     path, timer base addresses, interrupt masks, etc.).
+   - `sys_init.c` to open and map those peripherals using your OS/BSP APIs.
+   - The local `CMakeLists.txt` to pull in any extra sources or libraries that
+     your port requires.
+2. **Create a remote machine module.** Mirror the process under
+   `machine/remote/<new_machine>`, providing:
+   - `common.h` and `sys_init.*` that describe the remote-side peripherals.
+   - A `system/<rtos>` subdirectory if you need RTOS glue (see the FreeRTOS
+     example for structure).
+   - A linker script or scatter file that matches your memory map.
+3. **Select your machine at configure time.** Point CMake to the new directories
+   with:
+   ```bash
+   cmake -DDEMO=irq_shmem_demo \
+         -DROLE=host \
+         -DPROJECT_MACHINE=acme_linux_userspace \
+         …
+   ```
+   and similarly for the remote role. If you have multiple RTOS options, also
+   set `-DPROJECT_SYSTEM=<system_subdir>`.
+4. **Adjust platform macros and dependencies.** Update your toolchain file (or
+   pass `-DPLATFORM_*` definitions) so the machine layer selects the correct
+   peripheral map. Add any BSP or HAL libraries via `CMAKE_LIBRARY_PATH`,
+   `USER_LINK_DIRECTORIES`, or the machine-specific `CMakeLists.txt`.
+
+Once those layers are in place, the existing demo sources build and run without
+code changes, providing a consistent validation of libmetal primitives on your
+hardware.

--- a/examples/libmetal/demos/CMakeLists.txt
+++ b/examples/libmetal/demos/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+add_subdirectory (${DEMO})

--- a/examples/libmetal/demos/irq_shmem_demo/CMakeLists.txt
+++ b/examples/libmetal/demos/irq_shmem_demo/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+add_subdirectory(${ROLE})

--- a/examples/libmetal/demos/irq_shmem_demo/README.md
+++ b/examples/libmetal/demos/irq_shmem_demo/README.md
@@ -1,0 +1,22 @@
+# IRQ Shared Memory Demo
+
+This README captures information that is shared between the host and remote
+machine configurations for the IRQ shared memory demo.
+
+## Shared Memory Layout
+
+Both sides of the demo operate on the same shared-memory window. Offsets below
+reflect the AMD reference design; adjust the base address to match the target
+platform.
+
+| Offset Range        | Description                                                          |
+|---------------------|----------------------------------------------------------------------|
+| 0x00000 – 0x00003   | Number of Host-to-Remote buffers available to the remote             |
+| 0x00004 – 0x00007   | Number of Host-to-Remote buffers consumed by the remote              |
+| 0x00008 – 0x01FFC   | Address array for Host-to-Remote shared buffers                      |
+| 0x02000 – 0x02003   | Number of Remote-to-Host buffers available to the host               |
+| 0x02004 – 0x02007   | Number of Remote-to-Host buffers consumed by the host                |
+| 0x02008 – 0x03FFC   | Address array for Remote-to-Host shared buffers                      |
+| 0x04000 – 0x103FFC  | Host-to-Remote payload buffers                                       |
+| 0x104000 – 0x203FFC | Remote-to-Host payload buffers                                       |
+

--- a/examples/libmetal/demos/irq_shmem_demo/host/CMakeLists.txt
+++ b/examples/libmetal/demos/irq_shmem_demo/host/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+collect (APP_COMMON_SOURCES irq_shmem_demo.c)

--- a/examples/libmetal/demos/irq_shmem_demo/host/README.md
+++ b/examples/libmetal/demos/irq_shmem_demo/host/README.md
@@ -1,0 +1,12 @@
+# IRQ Shared Memory Demo – Host Side
+
+The host application publishes timestamped packets into a shared-memory window,
+signals the remote processor via IPI, and waits for the echoed payloads to
+measure round-trip latency. After the final message it sends a `"shutdown"`
+marker to stop the remote task.
+
+## Supported Platforms
+- [AMD Linux Userspace](../../../machine/host/amd_linux_userspace/README.md)
+
+Platform-specific prerequisites, build instructions, and troubleshooting tips
+live in the linked machine documentation.

--- a/examples/libmetal/demos/irq_shmem_demo/host/irq_shmem_demo.c
+++ b/examples/libmetal/demos/irq_shmem_demo/host/irq_shmem_demo.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * irq_shmem_demo.c - shared memory with IRQ demo
+ *
+ * This demo will:
+ * 1. Open the shared memory device.
+ * 2. Open the IRQ device.
+ * 3. Register the IRQ interrupt handler.
+ * 4. Write a message to the shared memory.
+ * 5. Kick the IRQ to notify the remote there is a new message.
+ * 6. Wait until the remote notifies that the message was echoed back.
+ * 7. Read the message from shared memory.
+ * 8. Verify the message.
+ * 9. Repeat steps 4 to 8 for 100 iterations.
+ * 10. Clean up: deregister the IRQ handler, close the IRQ device, and close the
+ *     shared memory device.
+ *
+ * Shared-memory partitioning details are documented in machine/host/
+ * amd_linux_userspace/README.md.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <metal/sys.h>
+#include <metal/io.h>
+#include <metal/alloc.h>
+#include <sys/types.h>
+#include <metal/device.h>
+#include <metal/irq.h>
+#include <metal/errno.h>
+
+#include "common.h"
+#include "platform_init.h"
+
+/* Shared memory offsets */
+#define SHM_DESC_OFFSET_TX 0x0
+#define SHM_BUFF_OFFSET_TX 0x04000
+#define SHM_DESC_OFFSET_RX 0x02000
+#define SHM_BUFF_OFFSET_RX 0x104000
+
+/* Shared memory descriptors offset */
+#define SHM_DESC_AVAIL_OFFSET 0x00
+#define SHM_DESC_USED_OFFSET  0x04
+#define SHM_DESC_ADDR_ARRAY_OFFSET 0x08
+
+#define PKGS_TOTAL 1024
+
+#define BUF_SIZE_MAX 512
+#define SHUTDOWN "shutdown"
+
+#define NS_PER_S  (1000 * 1000 * 1000)
+
+struct msg_hdr_s {
+	uint32_t index;
+	uint32_t len;
+};
+
+/**
+ * @brief wait_for_notified() - Loop until notified bit in channel is set.
+ *
+ * @param[in] notified - pointer to the notified variable
+ */
+static inline void wait_for_notified(atomic_flag *notified)
+{
+	unsigned int flags;
+
+	do {
+		flags = metal_irq_save_disable();
+		if (!atomic_flag_test_and_set(notified)) {
+			metal_irq_restore_enable(flags);
+			break;
+		}
+		metal_cpu_yield();
+		metal_irq_restore_enable(flags);
+	} while (1);
+}
+
+/**
+ * @brief dump_buffer() - print hex value of each byte in the buffer
+ *
+ * @param[in] buf - pointer to the buffer
+ * @param[in] len - len of the buffer
+ */
+static inline void dump_buffer(void *buf, unsigned int len)
+{
+	unsigned int i;
+	unsigned char *tmp = (unsigned char *)buf;
+
+	for (i = 0; i < len; i++) {
+		metal_info("HOST:  %02x", *(tmp++));
+		if (!(i % 20))
+			metal_info("HOST:\n");
+	}
+	metal_info("HOST:\n");
+}
+
+/**
+ * @brief   irq_shmem_echo() - shared memory IRQ demo
+ *          This task will:
+ *          * Get the timestamp and put it into the ping shared memory
+ *          * Update the shared memory descriptor for the new available
+ *            ping buffer.
+ *          * Trigger IRQ to notifty the remote.
+ *          * Repeat the above steps until it sends out all the packages.
+ *          * Monitor IRQ interrupt, verify every received package.
+ *          * After all the packages are received, it sends out shutdown
+ *            message to the remote.
+ *
+ * @param[in] ch - communication channel used
+ * @return - return 0 on success, otherwise return error number indicating
+ *           type of error.
+ */
+static int irq_shmem_echo(struct channel_s *ch)
+{
+	struct metal_io_region *shm_io = ch->shm_io;
+	unsigned long tx_avail_offset, rx_avail_offset;
+	unsigned long tx_addr_offset, rx_addr_offset;
+	unsigned long tx_data_offset, rx_data_offset;
+	void *txbuf = NULL, *rxbuf = NULL, *tmpptr;
+	long long tdiff_avg_s = 0, tdiff_avg_ns = 0;
+	unsigned long long tstart, tend;
+	unsigned long rx_used_offset;
+	struct msg_hdr_s *msg_hdr;
+	uint32_t tx_phy_addr_32;
+	uint32_t rx_avail;
+	long long tdiff;
+	uint32_t i;
+	int ret;
+
+	txbuf = metal_allocate_memory(BUF_SIZE_MAX);
+	if (!txbuf) {
+		metal_err("HOST: Failed to allocate local tx buffer for msg.\n");
+		ret = -ENOMEM;
+		goto out;
+	}
+	rxbuf = metal_allocate_memory(BUF_SIZE_MAX);
+	if (!rxbuf) {
+		metal_err("HOST: Failed to allocate local rx buffer for msg.\n");
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	/* Clear shared memory */
+	metal_io_block_set(shm_io, 0, 0, metal_io_region_size(shm_io));
+
+	/* Set tx/rx buffer address offset */
+	tx_avail_offset = SHM_DESC_OFFSET_TX + SHM_DESC_AVAIL_OFFSET;
+	rx_avail_offset = SHM_DESC_OFFSET_RX + SHM_DESC_AVAIL_OFFSET;
+	rx_used_offset = SHM_DESC_OFFSET_RX + SHM_DESC_USED_OFFSET;
+	tx_addr_offset = SHM_DESC_OFFSET_TX + SHM_DESC_ADDR_ARRAY_OFFSET;
+	rx_addr_offset = SHM_DESC_OFFSET_RX + SHM_DESC_ADDR_ARRAY_OFFSET;
+	tx_data_offset = SHM_DESC_OFFSET_TX + SHM_BUFF_OFFSET_TX;
+	rx_data_offset = SHM_DESC_OFFSET_RX + SHM_BUFF_OFFSET_RX;
+
+	metal_info("HOST: Start echo flood testing....\n");
+	metal_info("HOST: Sending msgs to the remote.\n");
+
+	for (i = 0; i < PKGS_TOTAL; i++) {
+
+		/* Construct a message to send */
+		tmpptr = txbuf;
+		msg_hdr = tmpptr;
+		msg_hdr->index = i;
+		msg_hdr->len = sizeof(tstart);
+		tmpptr += sizeof(struct msg_hdr_s);
+		tstart = platform_gettime();
+		*(unsigned long long *)tmpptr = tstart;
+
+		/* Copy message to shared buffer. */
+		metal_io_block_write(shm_io, tx_data_offset, msg_hdr,
+				     sizeof(struct msg_hdr_s) + msg_hdr->len);
+
+		/* Write to the address array to tell the other end the buffer address. */
+		tx_phy_addr_32 = (uint32_t)metal_io_phys(shm_io, tx_data_offset);
+		metal_io_write32(shm_io, tx_addr_offset, tx_phy_addr_32);
+		tx_data_offset += sizeof(struct msg_hdr_s) + msg_hdr->len;
+		tx_addr_offset += sizeof(uint32_t);
+
+		/* Increase number of available buffers */
+		metal_io_write32(shm_io, tx_avail_offset, (i + 1));
+		/* Kick IRQ to notify data has been put to shared buffer */
+		irq_kick(ch);
+	}
+	metal_info("HOST: Waiting for messages to echo back and verify.\n");
+	i = 0;
+	tx_data_offset = SHM_DESC_OFFSET_TX + SHM_BUFF_OFFSET_TX;
+	while (i != PKGS_TOTAL) {
+		wait_for_notified(&ch->remote_nkicked);
+		rx_avail = metal_io_read32(shm_io, rx_avail_offset);
+		while (i != rx_avail) {
+			uint32_t rx_phy_addr_32;
+
+			/* Received pong from the other side */
+
+			/*
+			 * Get the buffer location from the shared memory RX address array.
+			 */
+			rx_phy_addr_32 = metal_io_read32(shm_io, rx_addr_offset);
+			rx_data_offset = metal_io_phys_to_offset(shm_io,
+								 (metal_phys_addr_t)rx_phy_addr_32);
+			if (rx_data_offset == METAL_BAD_OFFSET) {
+				metal_err("HOST: failed to get rx [%d] offset: 0x%x.\n",
+					  i, rx_phy_addr_32);
+				ret = -EINVAL;
+				goto out;
+			}
+			rx_addr_offset += sizeof(rx_phy_addr_32);
+
+			/* Read message header from shared memory */
+			metal_io_block_read(shm_io, rx_data_offset, rxbuf,
+					    sizeof(struct msg_hdr_s));
+			msg_hdr = (struct msg_hdr_s *)rxbuf;
+
+			/* Check if the message header is valid */
+			if (msg_hdr->index != (uint32_t)i) {
+				metal_err("HOST: wrong msg: expected: %d, actual: %d\n",
+					  i, msg_hdr->index);
+				ret = -EINVAL;
+				goto out;
+			}
+			if (msg_hdr->len != sizeof(tstart)) {
+				metal_err("HOST: wrong msg: length invalid: %lu, %u.\n",
+					  sizeof(tstart), msg_hdr->len);
+				ret = -EINVAL;
+				goto out;
+			}
+			/* Read message */
+			rx_data_offset += sizeof(*msg_hdr);
+			metal_io_block_read(shm_io, rx_data_offset,
+					    rxbuf + sizeof(*msg_hdr), msg_hdr->len);
+			rx_data_offset += msg_hdr->len;
+			/*
+			 * Increase RX used count to indicate it has consumed the received data.
+			 */
+			metal_io_write32(shm_io, rx_used_offset, (i + 1));
+
+			/* Verify message */
+			/* Get tx message previously sent*/
+			metal_io_block_read(shm_io, tx_data_offset, txbuf,
+					    sizeof(*msg_hdr) + sizeof(tstart));
+			tx_data_offset += sizeof(*msg_hdr) + sizeof(tstart);
+			/* Compare the received message and the sent message */
+			ret = memcmp(rxbuf, txbuf, sizeof(*msg_hdr) + sizeof(tstart));
+			if (ret) {
+				metal_err("HOST: data[%u] verification failed.\n", i);
+				metal_info("HOST: Expected:");
+				dump_buffer(txbuf,	sizeof(*msg_hdr) + sizeof(tstart));
+				metal_info("HOST: Actual:");
+				dump_buffer(rxbuf, sizeof(*msg_hdr) + sizeof(tstart));
+				ret = -EINVAL;
+				goto out;
+			}
+
+			i++;
+		}
+	}
+	tend = platform_gettime();
+	tdiff = tend - tstart;
+
+	/* Send shutdown message */
+	tmpptr = txbuf;
+	msg_hdr = tmpptr;
+	msg_hdr->index = i;
+	msg_hdr->len = strlen(SHUTDOWN);
+	tmpptr += sizeof(struct msg_hdr_s);
+	sprintf(tmpptr, SHUTDOWN);
+	/* copy message to shared buffer */
+	metal_io_block_write(shm_io, tx_data_offset, msg_hdr,
+			     sizeof(struct msg_hdr_s) + msg_hdr->len);
+
+	tx_phy_addr_32 = (uint32_t)metal_io_phys(shm_io, tx_data_offset);
+	metal_io_write32(shm_io, tx_addr_offset, tx_phy_addr_32);
+	metal_io_write32(shm_io, tx_avail_offset, PKGS_TOTAL + 1);
+	metal_info("HOST: Kick remote to notify shutdown message sent...\n");
+	irq_kick(ch);
+
+	tdiff /= PKGS_TOTAL;
+	tdiff_avg_s = tdiff / NS_PER_S;
+	tdiff_avg_ns = tdiff % NS_PER_S;
+	metal_info("HOST: Total packages: %d, time_avg = %lds, %ldns\n",
+		   i, (long int)tdiff_avg_s, (long int)tdiff_avg_ns);
+
+	ret = 0;
+out:
+	if (txbuf)
+		metal_free_memory(txbuf);
+	if (rxbuf)
+		metal_free_memory(rxbuf);
+
+	return ret;
+}
+
+int main(void)
+{
+	struct channel_s ch_s;
+	int ret = 0;
+
+	/* platform_init will set the OS agnostic channel information */
+	ret = platform_init(&ch_s);
+	if (ret) {
+		metal_err("HOST: Failed to initialize system.\n");
+		return ret;
+	}
+
+	metal_info("HOST: IRQ and shared memory");
+	/* Run atomic operation demo */
+	ret = irq_shmem_echo(&ch_s);
+
+	platform_cleanup(&ch_s);
+	return ret;
+}

--- a/examples/libmetal/demos/irq_shmem_demo/remote/CMakeLists.txt
+++ b/examples/libmetal/demos/irq_shmem_demo/remote/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+collect (APP_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/irq_shmem_demo.c)

--- a/examples/libmetal/demos/irq_shmem_demo/remote/README.md
+++ b/examples/libmetal/demos/irq_shmem_demo/remote/README.md
@@ -1,0 +1,22 @@
+# IRQ Shared Memory Demo – Remote Side
+
+The remote firmware receives timestamped packets from the host, mirrors each
+payload into the return buffer, and notifies the host via IPI. When a
+`"shutdown"` marker arrives it disables interrupts and exits the loop.
+
+## Demo Sequence
+1. Get the shared memory device I/O region.
+2. Get the IRQ device I/O region.
+3. Register the IRQ interrupt handler.
+4. Wait for remote IRQ notification to receive a message.
+5. When a message is received, check whether it is the shutdown marker.
+6. If it is shutdown, clean up; otherwise, echo it back to the shared buffer.
+7. Kick IRQ to notify the host that a message was written into shared memory.
+8. Repeat step 4.
+9. Clean up: disable the IRQ interrupt and deregister the handler.
+
+## Supported Platforms
+- [AMD RPU (FreeRTOS)](../../../machine/remote/amd_rpu/README.md)
+
+Platform-specific prerequisites, build instructions, and troubleshooting tips
+live in the linked machine documentation.

--- a/examples/libmetal/demos/irq_shmem_demo/remote/irq_shmem_demo.c
+++ b/examples/libmetal/demos/irq_shmem_demo/remote/irq_shmem_demo.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * irq_shmem_demo.c - shared memory with IRQ demo
+ *
+ * Demo sequence details are documented in README.md.
+ *
+ * Shared-memory partitioning details are documented in machine/remote/amd_rpu/
+ * README.md.
+ */
+
+#include <stdbool.h>
+
+#include "common.h"
+
+#define BUF_SIZE_MAX 512
+#define SHUTDOWN "shutdown"
+
+/* Shared memory offsets */
+#define SHM_DESC_OFFSET_RX 0x0
+#define SHM_BUFF_OFFSET_RX 0x04000
+#define SHM_DESC_OFFSET_TX 0x02000
+#define SHM_BUFF_OFFSET_TX 0x104000
+
+/* Shared memory descriptors offset */
+#define SHM_DESC_AVAIL_OFFSET 0x00
+#define SHM_DESC_USED_OFFSET  0x04
+#define SHM_DESC_ADDR_ARRAY_OFFSET 0x08
+
+#define PKGS_TOTAL 1024
+
+/**
+ * @brief   demo() - shared memory IRQ demo
+ *	  This task will:
+ *	  * Wait for an IRQ interrupt from the host.
+ *	  * Copy the ping buffer into the pong buffer after each notification.
+ *	  * Update the shared memory descriptor for the new available pong buffer.
+ *	  * Trigger an IRQ to notify the host.
+ * @param[in] ch - channel structure
+ * @return - return 0 on success, otherwise return error number indicating
+ *		 type of error.
+ */
+int demo(void *arg)
+{
+	unsigned long tx_avail_offset, rx_avail_offset;
+	unsigned long tx_addr_offset, rx_addr_offset;
+	unsigned long tx_data_offset, rx_data_offset;
+	struct channel_s ch_s = {0x0};
+	unsigned long rx_used_offset;
+	struct channel_s *ch = &ch_s;
+	bool platform_ready = false;
+	uint32_t rx_count, rx_avail;
+	struct msg_hdr_s *msg_hdr;
+	void *lbuf = NULL;
+	char *payload;
+	int ret = 0;
+
+	/* platform_init will set the OS agnostic channel information */
+	ret = platform_init(&ch_s);
+	if (ret) {
+		metal_err("REMOTE: Failed to initialize system.\n");
+		goto out;
+	}
+	platform_ready = true;
+
+	/* OS specific setup for system suspend/resume done here. */
+	ret = amp_os_init(&ch_s, arg);
+	if (ret) {
+		metal_err("REMOTE: Failed to set task to system.\n");
+		goto out;
+	}
+
+	metal_info("REMOTE: IRQ and shared memory");
+
+	lbuf = metal_allocate_memory(BUF_SIZE_MAX);
+	if (!lbuf) {
+		metal_err("REMOTE: Failed to allocate local buffer for msg.\n");
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	/* Set tx/rx buffer address offset */
+	tx_avail_offset = SHM_DESC_OFFSET_TX + SHM_DESC_AVAIL_OFFSET;
+	rx_avail_offset = SHM_DESC_OFFSET_RX + SHM_DESC_AVAIL_OFFSET;
+	rx_used_offset = SHM_DESC_OFFSET_RX + SHM_DESC_USED_OFFSET;
+	tx_addr_offset = SHM_DESC_OFFSET_TX + SHM_DESC_ADDR_ARRAY_OFFSET;
+	rx_addr_offset = SHM_DESC_OFFSET_RX + SHM_DESC_ADDR_ARRAY_OFFSET;
+	tx_data_offset = SHM_DESC_OFFSET_TX + SHM_BUFF_OFFSET_TX;
+	rx_data_offset = SHM_DESC_OFFSET_RX + SHM_BUFF_OFFSET_RX;
+
+	metal_info("REMOTE: Wait for echo test to start.\n");
+	rx_count = 0;
+	while (1) {
+		system_suspend(ch);
+		rx_avail = metal_io_read32(ch->shm_io, rx_avail_offset);
+		while (rx_count != rx_avail) {
+			uint32_t buf_phy_addr;
+			/* Get the buffer location from the shared memory rx address array. */
+			buf_phy_addr = metal_io_read32(ch->shm_io, rx_addr_offset);
+			rx_data_offset = metal_io_phys_to_offset(ch->shm_io,
+								 (metal_phys_addr_t)buf_phy_addr);
+			if (rx_data_offset == METAL_BAD_OFFSET) {
+				metal_err("REMOTE: [%u]failed to get rx offset: 0x%x, 0x%lx.\n",
+					  rx_count, buf_phy_addr,
+					  metal_io_phys(ch->shm_io, rx_addr_offset));
+				ret = -EINVAL;
+				goto out;
+			}
+			rx_addr_offset += sizeof(buf_phy_addr);
+
+			/* Read message header from shared memory */
+			metal_io_block_read(ch->shm_io, rx_data_offset, lbuf,
+					    sizeof(struct msg_hdr_s));
+			msg_hdr = (struct msg_hdr_s *)lbuf;
+
+			/* Check if the message header is valid */
+			if (msg_hdr->len > (BUF_SIZE_MAX - sizeof(*msg_hdr))) {
+				metal_err("REMOTE: wrong msg: length invalid: %u, %u.\n",
+					  BUF_SIZE_MAX - sizeof(*msg_hdr), msg_hdr->len);
+				ret = -EINVAL;
+				goto out;
+			}
+			rx_data_offset += sizeof(*msg_hdr);
+			/* Read message body. */
+			metal_io_block_read(ch->shm_io, rx_data_offset, lbuf + sizeof(*msg_hdr),
+					    msg_hdr->len);
+			rx_data_offset += msg_hdr->len;
+			payload = (char *)lbuf + sizeof(*msg_hdr);
+			rx_count++;
+			/* Increase rx used count to indicate it has consumed the received data. */
+			metal_io_write32(ch->shm_io, rx_used_offset, rx_count);
+
+			/* Check if it is the shutdown message. */
+			if (msg_hdr->len == strlen(SHUTDOWN) && !strncmp(SHUTDOWN, payload,
+									 strlen(SHUTDOWN))) {
+				metal_info("REMOTE: Received shutdown message\n");
+				goto out;
+			}
+			/* Copy the message back to the other end. */
+			metal_io_block_write(ch->shm_io, tx_data_offset, msg_hdr,
+					     sizeof(struct msg_hdr_s) + msg_hdr->len);
+
+			/* Write to the address array to tell the other end the buffer address. */
+			buf_phy_addr = (uint32_t)metal_io_phys(ch->shm_io, tx_data_offset);
+			metal_io_write32(ch->shm_io, tx_addr_offset, buf_phy_addr);
+			tx_data_offset += sizeof(struct msg_hdr_s) + msg_hdr->len;
+			tx_addr_offset += sizeof(uint32_t);
+
+			/* Increase number of available buffers. */
+			metal_io_write32(ch->shm_io, tx_avail_offset, rx_count);
+
+			/* Kick IRQ to notify data is in shared buffer. */
+			irq_kick(ch);
+		}
+
+	}
+
+out:
+	metal_info("REMOTE: IRQ with shared memory demo finished with exit code: %i.\n", ret);
+
+	if (lbuf)
+		metal_free_memory(lbuf);
+
+	if (platform_ready)
+		platform_cleanup(&ch_s);
+
+	return ret;
+}

--- a/examples/libmetal/machine/CMakeLists.txt
+++ b/examples/libmetal/machine/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+add_subdirectory(${ROLE})

--- a/examples/libmetal/machine/host/CMakeLists.txt
+++ b/examples/libmetal/machine/host/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+add_subdirectory(${PROJECT_MACHINE})

--- a/examples/libmetal/machine/host/amd_linux_userspace/CMakeLists.txt
+++ b/examples/libmetal/machine/host/amd_linux_userspace/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+include (CheckIncludeFiles)
+include (CheckCSourceCompiles)
+include (${APPS_ROOT_DIR}/../legacy_apps/cmake/options.cmake)
+include (${APPS_ROOT_DIR}/../legacy_apps/cmake/collect.cmake)
+
+collect (APP_COMMON_SOURCES ipi-uio.c)
+collect (APP_COMMON_SOURCES platform_init.c)
+collect (APP_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
+
+set (_elf_name ${DEMO})
+
+collector_list  (_list PROJECT_INC_DIRS)
+include_directories (${_list} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_INCLUDE_PATH})
+
+collector_list  (_list PROJECT_LIB_DIRS)
+link_directories (${_list})
+
+collect(PROJECT_LIB_DEPS metal)
+collector_list (_deps PROJECT_LIB_DEPS)
+
+get_property (_ec_flgs GLOBAL PROPERTY "PROJECT_EC_FLAGS")
+set (_app ${DEMO})
+collector_list (_src APP_COMMON_SOURCES)
+
+if (WITH_STATIC_LIB)
+  add_executable (${_app}-static ${_src})
+  if (PROJECT_EC_FLAGS)
+    string(REPLACE " " ";" _ec_flgs ${PROJECT_EC_FLAGS})
+    target_compile_options (${_app}-static PUBLIC ${_ec_flgs})
+  endif (PROJECT_EC_FLAGS)
+  target_link_libraries (${_app}-static ${_deps} -L${CMAKE_LIBRARY_PATH})
+  install (TARGETS ${_app}-static RUNTIME DESTINATION bin)
+endif (WITH_STATIC_LIB)

--- a/examples/libmetal/machine/host/amd_linux_userspace/README.md
+++ b/examples/libmetal/machine/host/amd_linux_userspace/README.md
@@ -1,0 +1,70 @@
+# AMD Linux Userspace Host Platform
+
+## Overview
+This document captures the platform-specific details needed to run the IRQ
+shared-memory demo on a Linux host processor. The host application cooperates
+with the remote firmware at `demos/irq_shmem_demo/remote/irq_shmem_demod.c`,
+using a shared-memory window and IPI notifications to exchange timestamped
+messages.
+
+> Historical documentation may refer to the host processor as the “APU” and the
+> remote processor as the “RPU”. Within this guide we consistently use
+> Host/Remote terminology.
+
+## Host Demo Behaviour
+- Maps the shared memory, TTC timer, and IPI UIO devices required to exchange messages with the remote firmware.
+- Registers the IPI interrupt handler, posts a “demo started” marker in shared memory, and enables IPI delivery.
+- For each latency sample (default 1000 iterations), resets the host-to-remote timer, triggers an IPI, waits for the remote response, and records both directions of travel time.
+- Aggregates the collected counter values into average latency metrics and writes them back into the shared buffer for the remote to read.
+- Signals completion via IPI and then disables the interrupt and releases the mapped devices.
+
+## Prerequisites
+- Linux kernel exposes the shared memory (`3ed80000.shm` UIO on AMD SoCs; adjust
+  to the platform-specific device/offset), IPI, and TTC peripherals to
+  userspace with permissions suitable for the demo binary.
+- libmetal (and dependent libraries) installed on the host system, as well as
+  the `metal_xlnx_extension` library when required by the platform glue.
+- The project toolchain file defines the correct platform macro (for example,
+  `-DPLATFORM_ZYNQMP`) so `common.h` selects the matching peripheral map.
+- Remote firmware is already loaded and waiting for interrupts before the host
+  demo starts.
+
+## Configure & Build
+From `examples/libmetal`, configure CMake with the desired output directory and
+library/include search paths:
+
+```bash
+cmake -S . -B build_host \
+  -DCMAKE_TOOLCHAIN_FILE=$(pwd)/toolchain_file \
+  -DCMAKE_INCLUDE_PATH="/path/to/libmetal/include" \
+  -DCMAKE_LIBRARY_PATH="/path/to/libmetal/lib" \
+  -DDEMO=irq_shmem_demo \
+  -DROLE=host \
+  -DPROJECT_MACHINE=amd_linux_userspace
+
+cmake --build build_host --target irq_shmem_demo-static
+```
+
+The static executable is emitted at
+`build_host/machine/host/amd_linux_userspace/irq_shmem_demo-static`.
+
+## Run
+1. Start the remote firmware so it sits in the notification loop.
+2. Launch the host binary (root/sudo may be required for IPI device access):
+   ```bash
+   ./irq_shmem_demo-static
+   ```
+3. Observe the console output for packet progress and the final average
+   round-trip latency.
+
+## [Shared Memory Layout](../../../demos/irq_shmem_demo/README.md#shared-memory-layout)
+Shared buffer map used by both sides of the demo.
+
+## Troubleshooting
+- **Hangs waiting for notification**: ensure the IPI mask configured in
+  `common.h` matches the remote firmware and that the host process can write to
+  the IPI device.
+- **Shared-memory access errors**: confirm the UIO entry exposes the expected
+  physical range (`0x3ED80000`) with read/write permissions for the demo user.
+- **Mismatched payloads**: verify both sides agree on descriptor offsets and
+  the `PKGS_TOTAL` value compiled into each binary.

--- a/examples/libmetal/machine/host/amd_linux_userspace/common.h
+++ b/examples/libmetal/machine/host/amd_linux_userspace/common.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __COMMON_H__
+#define __COMMON_H__
+
+#include <sys/types.h>
+
+#include <metal/atomic.h>
+#include <metal/assert.h>
+#include <metal/cpu.h>
+#include <metal/irq.h>
+
+#include <stdio.h>
+
+#define BUS_NAME        "platform"
+
+#ifndef SHM_DEV_NAME
+#define SHM_DEV_NAME    "3ed80000.shm"
+#endif /* !SHM_DEV_NAME */
+
+#if defined(PLATFORM_ZYNQMP)
+
+#ifndef IPI_DEV_NAME
+#define IPI_DEV_NAME "ff340000.ipi"
+#endif /* !IPI_DEV_NAME */
+
+#ifndef TTC_DEV_NAME
+#define TTC_DEV_NAME "ff110000.timer"
+#endif /* !TTC_DEV_NAME */
+
+#ifndef IPI_MASK
+#define IPI_MASK 0x100
+#endif /* !IPI_MASK */
+
+#elif defined(versal)
+
+#ifndef IPI_DEV_NAME
+#define IPI_DEV_NAME "ff360000.ipi"
+#endif /* !IPI_DEV_NAME */
+
+#ifndef IPI_MASK
+#define IPI_MASK 0x08
+#endif /* !IPI_MASK */
+
+#ifndef TTC_DEV_NAME
+#define TTC_DEV_NAME "ff0e0000.ttc0"
+#endif /* TTC_DEV_NAME */
+
+#elif defined(VERSAL_NET)
+
+#ifndef IPI_DEV_NAME
+#define IPI_DEV_NAME "eb3600000.ipi"
+#endif /* !IPI_DEV_NAME */
+
+#ifndef IPI_MASK
+#define IPI_MASK 0x08
+#endif /* !IPI_MASK */
+
+#ifdef IS_VERSALGEN2
+
+#ifndef TTC_DEV_NAME
+#define TTC_DEV_NAME "f1e60000.ttc0"
+#endif /* !TTC_DEV_NAME */
+
+#else /* Versal NET case */
+
+#ifndef TTC_DEV_NAME
+#define TTC_DEV_NAME "fd1c0000.ttc0"
+#endif /* !TTC_DEV_NAME */
+
+#endif /* IS_VERSALGEN2 */
+
+#endif
+
+/*
+ * Apply this snippet to the device tree in an overlay so that Linux userspace can
+ * see and use TTC0:
+ *   &TTC0 {
+ *         compatible = "ttc0_libmetal_demo";
+ *         status = "okay";
+ * };
+ */
+
+/* IPI registers offset */
+#define IPI_TRIG_OFFSET 0x0  /* IPI trigger reg offset */
+#define IPI_OBS_OFFSET  0x4  /* IPI observation reg offset */
+#define IPI_ISR_OFFSET  0x10 /* IPI interrupt status reg offset */
+#define IPI_IMR_OFFSET  0x14 /* IPI interrupt mask reg offset */
+#define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
+#define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
+
+/* TTC counter offsets */
+#define XTTCPS_CLK_CNTRL_OFFSET 0x0  /* TTC counter clock control reg offset */
+#define XTTCPS_CNT_CNTRL_OFFSET 0xC  /* TTC counter control reg offset */
+#define XTTCPS_CNT_VAL_OFFSET   0x18 /* TTC counter val reg offset */
+#define XTTCPS_CNT_OFFSET(ID) ((ID) == 1 ? 0 : 1 << (ID)) /* TTC counter offset
+							     ID is from 1 to 3 */
+
+/* TTC counter control masks */
+#define XTTCPS_CNT_CNTRL_RST_MASK  0x10U /* TTC counter control reset mask */
+#define XTTCPS_CNT_CNTRL_DIS_MASK  0x01U /* TTC counter control disable mask */
+
+/**
+ * @brief ipi_kick_register_handler() - register for IPI kick handler
+ *
+ * @param[in] hd - handler function
+ * @param[in] priv - private data will be passed to the handler
+ */
+void ipi_kick_register_handler(metal_irq_handler hd, void *priv);
+
+/**
+ * @brief init_ipi() - Initialize IPI
+ *
+ * @return return 0 for success, negative value for failure.
+ */
+int init_ipi(void);
+
+/**
+ * @brief deinit_ipi() - Deinitialize IPI
+ */
+void deinit_ipi(void);
+
+/**
+ * @brief kick_ipi() - kick remote with IPI
+ */
+void kick_ipi(void *msg);
+
+/**
+ * @brief disable_ipi_kick() - disable IPI interrupt from remote kick
+ */
+void disable_ipi_kick(void);
+
+/**
+ * @brief enable_ipi_kick() - enable IPI interrupt from remote kick
+ */
+void enable_ipi_kick(void);
+
+/**
+ * @brief platform_gettime() - return platform-specific timestamp in ns
+ */
+unsigned long long platform_gettime(void);
+
+/**
+ * basic statistics
+ */
+struct metal_stat {
+	uint64_t st_cnt;
+	uint64_t st_sum;
+	uint64_t st_min;
+	uint64_t st_max;
+};
+#define STAT_INIT { .st_cnt = 0, .st_sum = 0, .st_min = ~0UL, .st_max = 0, }
+
+/**
+ * @brief update_stat() - update basic statistics
+ *
+ * @param[in] pst   - pointer to the struct stat
+ * @param[in] val - the value for the update
+ */
+static inline void update_stat(struct metal_stat *pst, uint64_t val)
+{
+	pst->st_cnt++;
+	pst->st_sum += val;
+	if (pst->st_min > val)
+		pst->st_min = val;
+	if (pst->st_max < val)
+		pst->st_max = val;
+}
+
+struct channel_s {
+	struct metal_io_region *ipi_io; /* IPI metal i/o region */
+	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
+	struct metal_io_region *ttc_io; /* TTC metal i/o region */
+	uint32_t ipi_mask; /* RPU IPI mask */
+	int irq_vector_id; /* IRQ number. */
+	atomic_flag remote_nkicked; /* IRQ kick flag */
+};
+
+/**
+ * @ AMD RPU port for IRQ notification
+ * @param[in] irq_io - IO region used for IRQ kick
+ */
+static inline void irq_kick(struct channel_s *ch)
+{
+	metal_assert(ch);
+	metal_io_write32(ch->ipi_io, IPI_TRIG_OFFSET, ch->ipi_mask);
+}
+#endif /* __COMMON_H__ */

--- a/examples/libmetal/machine/host/amd_linux_userspace/ipi-uio.c
+++ b/examples/libmetal/machine/host/amd_linux_userspace/ipi-uio.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * ipi_latency_demo.c
+ *
+ * Host-side demo behaviour is documented in README.md.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <metal/atomic.h>
+#include <metal/io.h>
+#include <metal/device.h>
+#include <metal/irq.h>
+#include "common.h"
+
+struct ipi_channel {
+	struct metal_device *ipi_dev; /**< ipi metal device */
+	struct metal_io_region *ipi_io; /**< ipi metal I/O region */
+	int ipi_irq; /**< ipi irq id */
+	uint32_t ipi_mask; /**< remote IPI mask */
+	metal_irq_handler ipi_kick_cb; /**< IPI kick callback */
+	void *ipi_kick_priv; /**< IPI kick callback private data */
+};
+
+static struct ipi_channel ipi_chnl;
+
+/**
+ * @brief ipi_irq_handler() - IPI interrupt handler
+ *        It will clear the notified flag to mark it's got an IPI interrupt.
+ *        It will stop the RPU->APU timer and will clear the notified
+ *        flag to mark it's got an IPI interrupt
+ *
+ * @param[in] vect_id - IPI interrupt vector ID
+ * @param[in/out] priv - communication channel data for this application.
+ *
+ * @return - If the IPI interrupt is triggered by its remote, it returns
+ *           METAL_IRQ_HANDLED. It returns METAL_IRQ_NOT_HANDLED, if it is
+ *           not the interrupt it expected.
+ *
+ */
+static int _ipi_irq_handler (int vect_id, void *priv)
+{
+	uint32_t val;
+	struct ipi_channel *chnl = (struct ipi_channel *)priv;
+	struct metal_io_region *io;
+
+	(void)vect_id;
+
+	io = chnl->ipi_io;
+	val = metal_io_read32(io, IPI_ISR_OFFSET);
+	if (val & chnl->ipi_mask) {
+		if (chnl->ipi_kick_cb != NULL)
+			chnl->ipi_kick_cb(vect_id, chnl->ipi_kick_priv);
+		metal_io_write32(io, IPI_ISR_OFFSET, chnl->ipi_mask);
+		return METAL_IRQ_HANDLED;
+	}
+	return METAL_IRQ_NOT_HANDLED;
+}
+
+static void _enable_ipi_intr(struct ipi_channel *chnl)
+{
+	metal_irq_enable(chnl->ipi_irq);
+	/* Enable IPI interrupt */
+	metal_io_write32(chnl->ipi_io, IPI_IER_OFFSET, chnl->ipi_mask);
+}
+
+static void _disable_ipi_intr(struct ipi_channel *chnl)
+{
+	/* disable IPI interrupt */
+	metal_io_write32(chnl->ipi_io, IPI_IDR_OFFSET, chnl->ipi_mask);
+	metal_irq_disable(ipi_chnl.ipi_irq);
+}
+
+void ipi_kick_register_handler(metal_irq_handler hd, void *priv)
+{
+	ipi_chnl.ipi_kick_cb = hd;
+	ipi_chnl.ipi_kick_priv = priv;
+}
+
+int init_ipi(void)
+{
+	struct metal_device *dev;
+	struct metal_io_region *io;
+	int ret;
+
+	/* Open IPI device */
+	ret = metal_device_open(BUS_NAME, IPI_DEV_NAME, &dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", IPI_DEV_NAME);
+		return ret;
+	}
+
+	/* Get IPI device IO region */
+	io = metal_device_io_region(dev, 0);
+	if (!io) {
+		metal_err("HOST: Failed to map io region for %s.\n", dev->name);
+		ret = -ENODEV;
+		metal_device_close(dev);
+		return ret;
+	}
+	ipi_chnl.ipi_dev = dev;
+	ipi_chnl.ipi_io = io;
+
+	/* Get the IPI IRQ from the opened IPI device */
+	ipi_chnl.ipi_irq = (intptr_t)dev->irq_info;
+
+	ipi_chnl.ipi_mask = IPI_MASK;
+	/* disable IPI interrupt */
+	_disable_ipi_intr(&ipi_chnl);
+	/* clear old IPI interrupt */
+	metal_io_write32(io, IPI_ISR_OFFSET, IPI_MASK);
+	/* Register IPI irq handler */
+	metal_irq_register(ipi_chnl.ipi_irq, _ipi_irq_handler, &ipi_chnl);
+	return 0;
+}
+
+void deinit_ipi(void)
+{
+	/* disable IPI interrupt */
+	_disable_ipi_intr(&ipi_chnl);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_unregister(ipi_chnl.ipi_irq);
+	if (ipi_chnl.ipi_dev) {
+		metal_device_close(ipi_chnl.ipi_dev);
+		ipi_chnl.ipi_dev = NULL;
+	}
+}
+
+void kick_ipi(void *msg)
+{
+	(void)msg;
+	metal_io_write32(ipi_chnl.ipi_io, IPI_TRIG_OFFSET, ipi_chnl.ipi_mask);
+}
+
+void disable_ipi_kick(void)
+{
+	_disable_ipi_intr(&ipi_chnl);
+}
+
+void enable_ipi_kick(void)
+{
+	_enable_ipi_intr(&ipi_chnl);
+}

--- a/examples/libmetal/machine/host/amd_linux_userspace/platform_init.c
+++ b/examples/libmetal/machine/host/amd_linux_userspace/platform_init.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <metal/device.h>
+#include <metal/sys.h>
+#include <metal/time.h>
+#include "common.h"
+
+static struct metal_device *shm_dev, *ipi_dev, *ttc_dev;
+/**
+ * @brief close_metal_devices() - close libmetal devices
+ *        This function closes all the libmetal devices which have
+ *        been opened.
+ *
+ */
+static void close_metal_devices(void)
+{
+	/* Close shared memory device */
+	if (shm_dev)
+		metal_device_close(shm_dev);
+
+	/* Close IPI device */
+	if (ipi_dev)
+		metal_device_close(ipi_dev);
+
+	/* Close TTC device */
+	if (ttc_dev)
+		metal_device_close(ttc_dev);
+}
+
+/**
+ * @brief open_metal_devices() - Open registered libmetal devices.
+ *        This function opens all the registered libmetal devices.
+ *
+ * @return 0 - succeeded, non-zero for failures.
+ */
+int open_metal_devices(void)
+{
+	int ret;
+
+	/* Open shared memory device */
+	ret = metal_device_open(BUS_NAME, SHM_DEV_NAME, &shm_dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", SHM_DEV_NAME);
+		goto out;
+	}
+
+	/* Open IPI device */
+	ret = metal_device_open(BUS_NAME, IPI_DEV_NAME, &ipi_dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", IPI_DEV_NAME);
+		goto out;
+	}
+
+	/* Open TTC device */
+	ret = metal_device_open(BUS_NAME, TTC_DEV_NAME, &ttc_dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", TTC_DEV_NAME);
+		goto out;
+	}
+
+out:
+	return ret;
+}
+
+static int irq_isr(int vect_id, void *priv)
+{
+	(void)vect_id;
+	struct channel_s *ch = (struct channel_s *)priv;
+	struct metal_io_region *ipi_io = ch->ipi_io;
+	uint32_t ipi_mask = IPI_MASK;
+	uint64_t val = 1;
+
+	if (!ipi_io)
+		return METAL_IRQ_NOT_HANDLED;
+	val = metal_io_read32(ipi_io, IPI_ISR_OFFSET);
+	if (val & ipi_mask) {
+		metal_io_write32(ipi_io, IPI_ISR_OFFSET, ipi_mask);
+		atomic_flag_clear(&ch->remote_nkicked);
+		return METAL_IRQ_HANDLED;
+	}
+	return METAL_IRQ_NOT_HANDLED;
+}
+
+int platform_init(struct channel_s *ch)
+{
+	struct metal_init_params init_param = METAL_INIT_DEFAULTS;
+	int ret;
+
+	metal_assert(ch);
+
+	ret = metal_init(&init_param);
+	if (ret) {
+		metal_err("HOST: Failed to initialize libmetal\n");
+		return ret;
+	}
+
+	/* initialize remote_nkicked */
+	ch->remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch->remote_nkicked);
+
+	ret = open_metal_devices();
+	if (ret) {
+		metal_err("HOST: Failed to open devices\n");
+		return ret;
+	}
+
+	/* Get shared memory device IO region */
+	ch->shm_io = metal_device_io_region(shm_dev, 0);
+	if (!ch->shm_io) {
+		metal_err("HOST: Failed to map io region for %s.\n", shm_dev->name);
+		return -ENODEV;
+	}
+
+	/* Get IPI device IO region */
+	ch->ipi_io = metal_device_io_region(ipi_dev, 0);
+	if (!ch->ipi_io) {
+		metal_err("HOST: Failed to map io region for %s.\n", ipi_dev->name);
+		return -ENODEV;
+	}
+
+	/* Get the IPI IRQ from the opened IPI device */
+	ch->ipi_mask = (intptr_t)ipi_dev->irq_info;
+
+	/* Get TTC IO region */
+	ch->ttc_io = metal_device_io_region(ttc_dev, 0);
+	if (!ch->ttc_io) {
+		metal_err("HOST: Failed to map io region for %s.\n", ttc_dev->name);
+		return -ENODEV;
+	}
+
+	/* disable IPI interrupt */
+	metal_io_write32(ch->ipi_io, IPI_IDR_OFFSET, IPI_MASK);
+	/* clear old IPI interrupt */
+	metal_io_write32(ch->ipi_io, IPI_ISR_OFFSET, IPI_MASK);
+	/* Register IPI irq handler */
+	metal_irq_register(ch->irq_vector_id, irq_isr, ch);
+	metal_irq_enable(ch->irq_vector_id);
+	/* Enable IPI interrupt */
+	metal_io_write32(ch->ipi_io, IPI_IER_OFFSET, IPI_MASK);
+
+	return 0;
+}
+
+void platform_cleanup(struct channel_s *ch)
+{
+	/* disable IPI interrupt */
+	metal_io_write32(ch->ipi_io, IPI_IDR_OFFSET, IPI_MASK);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_disable(ch->irq_vector_id);
+	metal_irq_unregister(ch->irq_vector_id);
+
+	metal_irq_unregister(ch->irq_vector_id);
+	memset(&ch, 0, sizeof(ch));
+
+	/* Close libmetal devices which have been opened */
+	close_metal_devices();
+	/* Finish libmetal environment */
+	metal_finish();
+}
+
+unsigned long long platform_gettime(void)
+{
+	return metal_get_timestamp();
+}
+
+void wait_for_interrupt(void)
+{
+}

--- a/examples/libmetal/machine/host/amd_linux_userspace/platform_init.h
+++ b/examples/libmetal/machine/host/amd_linux_userspace/platform_init.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __PLATFORM_INIT_H__
+#define __PLATFORM_INIT_H__
+
+#include "platform_init.h"
+
+int platform_init(struct channel_s *ch);
+void platform_cleanup(struct channel_s *ch);
+
+#endif /* __PLATFORM_INIT_H__ */

--- a/examples/libmetal/machine/remote/CMakeLists.txt
+++ b/examples/libmetal/machine/remote/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+add_subdirectory(${PROJECT_MACHINE})

--- a/examples/libmetal/machine/remote/amd_rpu/CMakeLists.txt
+++ b/examples/libmetal/machine/remote/amd_rpu/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+include(${CMAKE_CURRENT_SOURCE_DIR}/build_deps.cmake)
+
+include_directories(${CMAKE_BINARY_DIR}/include)
+
+add_subdirectory (system)
+
+set (_elf_name ${DEMO})
+
+set (source_dirs ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/system/${PROJECT_SYSTEM})
+link_directories(${source_dirs})
+include_directories(${source_dirs})
+
+collector_list (_deps PROJECT_LIB_DEPS)
+
+collector_list (_sources APP_COMMON_SOURCES)
+list(APPEND _sources ${CMAKE_CURRENT_SOURCE_DIR}/platform_init.c)
+
+set (_linker_script ${CMAKE_CURRENT_SOURCE_DIR}/lscript_sdt.ld)
+
+add_executable(${_elf_name}.elf ${_sources})
+
+# Add library search paths properly
+target_link_directories(${_elf_name}.elf PRIVATE
+  ${CMAKE_LIBRARY_PATH}
+  ${USER_LINK_DIRECTORIES}
+)
+
+target_link_libraries(${_elf_name}.elf PRIVATE
+  -Wl,-Map=${_elf_name}.map
+  -Wl,--gc-sections -T\"${_linker_script}\"
+  -Wl,--start-group ${_deps} -Wl,--end-group)
+
+target_compile_definitions(${_elf_name}.elf PUBLIC ${USER_COMPILE_DEFINITIONS})
+target_include_directories(${_elf_name}.elf PUBLIC ${USER_INCLUDE_DIRECTORIES})
+install (TARGETS ${_elf_name}.elf RUNTIME DESTINATION bin)

--- a/examples/libmetal/machine/remote/amd_rpu/README.md
+++ b/examples/libmetal/machine/remote/amd_rpu/README.md
@@ -1,0 +1,65 @@
+# AMD RPU Remote Platform
+
+## Overview
+This guide captures the platform-specific setup for running the IRQ shared
+memory demo on an AMD RPU executing FreeRTOS or bare-metal firmware. The remote
+binary at `demos/irq_shmem_demo/remote/irq_shmem_demod.c` services notifications
+from the host, echoes payloads through shared memory, and exits when the host
+sends a `"shutdown"` marker.
+
+> Historical documentation may refer to the host processor as the “APU” and the
+> remote processor as the “RPU”. Within this guide we consistently use
+> Host/Remote terminology.
+
+## Prerequisites
+- Cortex-R5 cross toolchain and BSP that provide the required headers and
+  libraries (`xilstandalone`, `xiltimer`, `xilpm`, etc.).
+- libmetal and the Xilinx libmetal extension libraries available to the
+  toolchain via the include/library search paths.
+- The linker script and BSP expose the shared memory window at `0x3ED80000`
+  together with the IPI and TTC peripherals described in `common.h`.
+- The CMake toolchain file used for configuration defines the correct platform
+  macro (for example, `-DPLATFORM_ZYNQMP`, `-Dversal`, or `-DVERSAL_NET`) so the
+  peripheral map matches the target silicon.
+- Start the host side after the remote firmware is loaded and waiting for
+  notifications.
+
+## Configure & Build
+From `examples/libmetal`, configure CMake with your cross toolchain, BSP, and
+library paths:
+
+```bash
+cmake -S . -B build_remote \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/rpu-toolchain.cmake \
+  -DCMAKE_INCLUDE_PATH="${LIBMETAL_BUILD_DIR}/include;${BSP_DIR}/include" \
+  -DCMAKE_LIBRARY_PATH="${LIBMETAL_BUILD_DIR}/lib;${BSP_DIR}/lib;${EXTENSION_LIB}" \
+  -DDEMO=irq_shmem_demo \
+  -DROLE=remote \
+  -DPROJECT_SYSTEM=freertos \
+  -DPROJECT_MACHINE=amd_rpu
+
+cmake --build build_remote --target irq_shmem_demo.elf
+```
+
+Build artefacts:
+- Executable ELF: `build_remote/machine/remote/amd_rpu/irq_shmem_demo.elf`
+- Linker map: `build_remote/machine/remote/amd_rpu/irq_shmem_demo.map`
+
+## Run
+1. Load `irq_shmem_demo.elf` onto the RPU using your preferred loader (XSDB,
+   OpenOCD, PLM, etc.) and start the core.
+2. Monitor the remote console for the `"libmetal demo"` banner and echo-test
+   progress. The firmware prints `"Received shutdown message"` when it exits.
+
+## [Shared Memory Layout](../../../demos/irq_shmem_demo/README.md#shared-memory-layout)
+Buffer layout shared between the host and remote binaries.
+
+## Troubleshooting
+- **No interrupts observed**: verify the platform macro in the toolchain file
+  matches the target device so the correct IPI/TTC base addresses are compiled
+  into the firmware.
+- **Shared memory offset errors**: ensure the linker script and MPU/cache
+  settings expose the `0x3ED80000` window coherently to both sides.
+- **Linker failures**: confirm the cross toolchain can locate libmetal,
+  `metal_xlnx_extension`, and BSP libraries through `CMAKE_INCLUDE_PATH` and
+  `CMAKE_LIBRARY_PATH`.

--- a/examples/libmetal/machine/remote/amd_rpu/common.h
+++ b/examples/libmetal/machine/remote/amd_rpu/common.h
@@ -1,0 +1,177 @@
+ /*
+  * Copyright (C) 2025, Advanced Micro Devices, Inc.
+  *
+  * SPDX-License-Identifier: BSD-3-Clause
+  */
+
+#ifndef __COMMON_H__
+#define __COMMON_H__
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <metal/atomic.h>
+#include <metal/alloc.h>
+#include <metal/irq.h>
+#include <metal/irq_controller.h>
+#include <metal/errno.h>
+#include <metal/sys.h>
+#include <metal/cpu.h>
+#include <metal/io.h>
+#include <metal/device.h>
+#include <sys/types.h>
+#include "platform_init.h"
+
+#include "xil_printf.h"
+#include "xil_exception.h"
+
+#include "amp_demo_os.h"
+
+#define TTC_CNT_APU_TO_RPU 2 /* APU to RPU TTC counter ID */
+#define TTC_CNT_RPU_TO_APU 3 /* RPU to APU TTC counter ID */
+
+#define TTC_CLK_FREQ_HZ	100000000
+
+/*
+ * For Versal and future SOCs, pm_defs.h exists today but will be
+ * deprecated. Use xpm_defs.h for those board families.
+ */
+#if defined(PLATFORM_ZYNQMP)
+#include "pm_defs.h"
+#else
+#include "xpm_nodeid.h"
+#endif
+
+#if defined(PLATFORM_ZYNQMP)
+
+#define TTC_NODEID NODE_TTC_0
+#define TTC0_BASE_ADDR 0xff110000
+#define TTC_DEV_NAME "ff110000.ttc"
+#define IPI_MASK 0x1000000
+
+#if XPAR_CPU_ID == 0
+#define IPI_DEV_NAME "ff310000.ipi"
+#define IPI_BASE_ADDR 0xff310000
+#define IPI_IRQ_VECT_ID 65
+#else
+#define IPI_DEV_NAME "ff320000.ipi"
+#define IPI_BASE_ADDR 0xff320000
+#define IPI_IRQ_VECT_ID 66
+#endif
+
+#elif defined(versal)
+#define TTC0_BASE_ADDR 0xFF0E0000
+#define IPI_BASE_ADDR 0xFF340000
+#define IPI_IRQ_VECT_ID 63
+#define IPI_MASK 0x0000020
+#define TTC_DEV_NAME "ff0e0000.ttc"
+#define IPI_DEV_NAME "ff340000.ipi"
+
+#elif defined(VERSAL_NET)
+
+#ifdef IS_VERSAL2
+
+#define TTC0_BASE_ADDR 0xF1E60000
+#define TTC_DEV_NAME "f1e60000.ttc"
+
+#else  /* Versal NET Case */
+
+#define TTC0_BASE_ADDR 0xFD1C0000
+#define TTC_DEV_NAME "fd1c0000.ttc"
+
+#endif /* IS_VERSAL2 */
+
+#define IPI_BASE_ADDR 0xEB340000
+#define IPI_IRQ_VECT_ID 90
+#define IPI_MASK 0x0000020
+#define IPI_DEV_NAME "eb340000.ipi"
+#endif
+
+/* Symbol name is same for all non-ZynqMP SOC's. */
+#ifndef PLATFORM_ZYNQMP
+#define TTC_NODEID PM_DEV_TTC_0
+#endif
+
+/* Devices names */
+#define BUS_NAME        "generic"
+#define SHM_DEV_NAME	"3ed80000.shm"
+
+#define SHM_BASE_ADDR   0x3ED80000
+
+/* IPI registers offset */
+#define IPI_TRIG_OFFSET 0x0  /* IPI trigger reg offset */
+#define IPI_OBS_OFFSET  0x4  /* IPI observation reg offset */
+#define IPI_ISR_OFFSET  0x10 /* IPI interrupt status reg offset */
+#define IPI_IMR_OFFSET  0x14 /* IPI interrupt mask reg offset */
+#define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
+#define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
+
+/* TTC counter offsets */
+#define XTTCPS_CLK_CNTRL_OFFSET 0x0  /* TTC counter clock control reg offset */
+#define XTTCPS_CNT_CNTRL_OFFSET 0xC  /* TTC counter control reg offset */
+#define XTTCPS_CNT_VAL_OFFSET   0x18 /* TTC counter val reg offset */
+#define XTTCPS_CNT_OFFSET(ID) ((ID) == 1 ? 0 : 1 << (ID))
+
+/* TTC counter control masks */
+#define XTTCPS_CNT_CNTRL_RST_MASK  0x10U /* TTC counter control reset mask */
+#define XTTCPS_CNT_CNTRL_DIS_MASK  0x01U /* TTC counter control disable mask */
+
+struct msg_hdr_s {
+	uint32_t index;
+	uint32_t len;
+};
+
+extern struct metal_device *ipi_dev; /* IPI metal device */
+extern struct metal_device *shm_dev; /* SHM metal device */
+extern struct metal_device *ttc_dev; /* TTC metal device */
+
+/**
+ * @brief reset_timer() - function to reset TTC counter
+ *        Set the RST bit in the Count Control Reg.
+ *
+ * @param[in] ttc_io - TTC timer i/o region
+ * @param[in] cnt_id - counter id
+ */
+static inline void reset_timer(struct metal_io_region *ttc_io,
+			unsigned long cnt_id)
+{
+	uint32_t val;
+	unsigned long offset = XTTCPS_CNT_CNTRL_OFFSET +
+				XTTCPS_CNT_OFFSET(cnt_id);
+
+	val = XTTCPS_CNT_CNTRL_RST_MASK;
+	metal_io_write32(ttc_io, offset, val);
+}
+
+/**
+ * @brief stop_timer() - function to stop TTC counter
+ *        Set the disable bit in the Count Control Reg.
+ *
+ * @param[in] ttc_io - TTC timer i/o region
+ * @param[in] cnt_id - counter id
+ */
+static inline void stop_timer(struct metal_io_region *ttc_io,
+			unsigned long cnt_id)
+{
+	uint32_t val;
+	unsigned long offset = XTTCPS_CNT_CNTRL_OFFSET +
+				XTTCPS_CNT_OFFSET(cnt_id);
+
+	val = XTTCPS_CNT_CNTRL_DIS_MASK;
+	metal_io_write32(ttc_io, offset, val);
+}
+
+/**
+ * @ AMD RPU port for IRQ notification
+ * @param[in] irq_io - IO region used for IRQ kick
+ */
+static inline void irq_kick(struct channel_s *ch)
+{
+	metal_assert(ch);
+	metal_io_write32(ch->ipi_io, IPI_TRIG_OFFSET, ch->ipi_mask);
+}
+
+int demo(void *arg);
+
+#endif /* __COMMON_H__ */

--- a/examples/libmetal/machine/remote/amd_rpu/lscript_sdt.ld
+++ b/examples/libmetal/machine/remote/amd_rpu/lscript_sdt.ld
@@ -1,0 +1,294 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2017 - 2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ ******************************************************************************/
+
+_STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 0x2000;
+_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0x4000;
+
+_ABORT_STACK_SIZE = DEFINED(_ABORT_STACK_SIZE) ? _ABORT_STACK_SIZE : 1024;
+_SUPERVISOR_STACK_SIZE = DEFINED(_SUPERVISOR_STACK_SIZE) ? _SUPERVISOR_STACK_SIZE : 2048;
+_IRQ_STACK_SIZE = DEFINED(_IRQ_STACK_SIZE) ? _IRQ_STACK_SIZE : 1024;
+_FIQ_STACK_SIZE = DEFINED(_FIQ_STACK_SIZE) ? _FIQ_STACK_SIZE : 1024;
+_UNDEF_STACK_SIZE = DEFINED(_UNDEF_STACK_SIZE) ? _UNDEF_STACK_SIZE : 1024;
+
+/* Define Memories in the system */
+
+MEMORY
+{
+   psu_r5_atcm_MEM_0 : ORIGIN = 0x0, LENGTH = 0x10000
+   psu_r5_btcm_MEM_0 : ORIGIN = 0x20000, LENGTH = 0x10000
+   psu_r5_ddr_0_MEM_0 : ORIGIN = 0x3ed00000, LENGTH = 0x80000
+}
+
+/* Specify the default entry point to the program */
+
+ENTRY(_vector_table)
+
+/* Define the sections, and where they are mapped in memory */
+
+SECTIONS
+{
+.vectors : {
+   KEEP (*(.vectors))
+   *(.boot)
+} > psu_r5_atcm_MEM_0
+
+.text : {
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   *(.plt)
+   *(.gnu_warning)
+   *(.gcc_execpt_table)
+   *(.glue_7)
+   *(.glue_7t)
+   *(.vfp11_veneer)
+   *(.ARM.extab)
+   *(.gnu.linkonce.armextab.*)
+} > psu_r5_ddr_0_MEM_0
+
+.init : {
+   KEEP (*(.init))
+} > psu_r5_btcm_MEM_0
+
+.fini : {
+   KEEP (*(.fini))
+} > psu_r5_btcm_MEM_0
+
+.interp : {
+   KEEP (*(.interp))
+} > psu_r5_btcm_MEM_0
+
+.note-ABI-tag : {
+   KEEP (*(.note-ABI-tag))
+} > psu_r5_btcm_MEM_0
+
+.rodata : {
+   __rodata_start = .;
+   *(.rodata)
+   *(.rodata.*)
+   *(.gnu.linkonce.r.*)
+   __rodata_end = .;
+} > psu_r5_btcm_MEM_0
+
+.rodata1 : {
+   __rodata1_start = .;
+   *(.rodata1)
+   *(.rodata1.*)
+   __rodata1_end = .;
+} > psu_r5_btcm_MEM_0
+
+.sdata2 : {
+   __sdata2_start = .;
+   *(.sdata2)
+   *(.sdata2.*)
+   *(.gnu.linkonce.s2.*)
+   __sdata2_end = .;
+} > psu_r5_btcm_MEM_0
+
+.sbss2 : {
+   __sbss2_start = .;
+   *(.sbss2)
+   *(.sbss2.*)
+   *(.gnu.linkonce.sb2.*)
+   __sbss2_end = .;
+} > psu_r5_btcm_MEM_0
+
+.data : {
+   __data_start = .;
+   *(.data)
+   *(.data.*)
+   *(.gnu.linkonce.d.*)
+   *(.jcr)
+   *(.got)
+   *(.got.plt)
+   __data_end = .;
+} > psu_r5_btcm_MEM_0
+
+.data1 : {
+   __data1_start = .;
+   *(.data1)
+   *(.data1.*)
+   __data1_end = .;
+} > psu_r5_btcm_MEM_0
+
+.got : {
+   *(.got)
+} > psu_r5_btcm_MEM_0
+
+.ctors : {
+   __CTOR_LIST__ = .;
+   ___CTORS_LIST___ = .;
+   KEEP (*crtbegin.o(.ctors))
+   KEEP (*(EXCLUDE_FILE(*crtend.o) .ctors))
+   KEEP (*(SORT(.ctors.*)))
+   KEEP (*(.ctors))
+   __CTOR_END__ = .;
+   ___CTORS_END___ = .;
+} > psu_r5_btcm_MEM_0
+
+.dtors : {
+   __DTOR_LIST__ = .;
+   ___DTORS_LIST___ = .;
+   KEEP (*crtbegin.o(.dtors))
+   KEEP (*(EXCLUDE_FILE(*crtend.o) .dtors))
+   KEEP (*(SORT(.dtors.*)))
+   KEEP (*(.dtors))
+   __DTOR_END__ = .;
+   ___DTORS_END___ = .;
+} > psu_r5_btcm_MEM_0
+
+.fixup : {
+   __fixup_start = .;
+   *(.fixup)
+   __fixup_end = .;
+} > psu_r5_btcm_MEM_0
+
+.eh_frame : {
+   *(.eh_frame)
+} > psu_r5_btcm_MEM_0
+
+.eh_framehdr : {
+   __eh_framehdr_start = .;
+   *(.eh_framehdr)
+   __eh_framehdr_end = .;
+} > psu_r5_btcm_MEM_0
+
+.gcc_except_table : {
+   *(.gcc_except_table)
+} > psu_r5_btcm_MEM_0
+
+.mmu_tbl (ALIGN(16384)) : {
+   __mmu_tbl_start = .;
+   *(.mmu_tbl)
+   __mmu_tbl_end = .;
+} > psu_r5_btcm_MEM_0
+
+.ARM.exidx : {
+   __exidx_start = .;
+   *(.ARM.exidx*)
+   *(.gnu.linkonce.armexidix.*.*)
+   __exidx_end = .;
+} > psu_r5_btcm_MEM_0
+
+.preinit_array : {
+   __preinit_array_start = .;
+   KEEP (*(SORT(.preinit_array.*)))
+   KEEP (*(.preinit_array))
+   __preinit_array_end = .;
+} > psu_r5_btcm_MEM_0
+
+.init_array : {
+   __init_array_start = .;
+   KEEP (*(SORT(.init_array.*)))
+   KEEP (*(.init_array))
+   __init_array_end = .;
+} > psu_r5_btcm_MEM_0
+
+.fini_array : {
+   __fini_array_start = .;
+   KEEP (*(SORT(.fini_array.*)))
+   KEEP (*(.fini_array))
+   __fini_array_end = .;
+} > psu_r5_btcm_MEM_0
+
+.ARM.attributes : {
+   __ARM.attributes_start = .;
+   *(.ARM.attributes)
+   __ARM.attributes_end = .;
+} > psu_r5_btcm_MEM_0
+
+.sdata : {
+   __sdata_start = .;
+   *(.sdata)
+   *(.sdata.*)
+   *(.gnu.linkonce.s.*)
+   __sdata_end = .;
+} > psu_r5_btcm_MEM_0
+
+.sbss (NOLOAD) : {
+   __sbss_start = .;
+   *(.sbss)
+   *(.sbss.*)
+   *(.gnu.linkonce.sb.*)
+   __sbss_end = .;
+} > psu_r5_btcm_MEM_0
+
+.tdata : {
+   __tdata_start = .;
+   *(.tdata)
+   *(.tdata.*)
+   *(.gnu.linkonce.td.*)
+   __tdata_end = .;
+} > psu_r5_btcm_MEM_0
+
+.tbss : {
+   __tbss_start = .;
+   *(.tbss)
+   *(.tbss.*)
+   *(.gnu.linkonce.tb.*)
+   __tbss_end = .;
+} > psu_r5_btcm_MEM_0
+
+.bss (NOLOAD) : {
+   . = ALIGN(4);
+   __bss_start__ = .;
+   *(.bss)
+   *(.bss.*)
+   *(.gnu.linkonce.b.*)
+   *(COMMON)
+   . = ALIGN(4);
+   __bss_end__ = .;
+} > psu_r5_ddr_0_MEM_0
+
+_SDA_BASE_ = __sdata_start + ((__sbss_end - __sdata_start) / 2 );
+
+_SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
+
+/* Generate Stack and Heap definitions */
+
+.heap (NOLOAD) : {
+   . = ALIGN(16);
+   _heap = .;
+   HeapBase = .;
+   _heap_start = .;
+   . += _HEAP_SIZE;
+   _heap_end = .;
+   HeapLimit = .;
+} > psu_r5_btcm_MEM_0
+
+.stack (NOLOAD) : {
+   . = ALIGN(16);
+   _stack_end = .;
+   . += _STACK_SIZE;
+   _stack = .;
+   __stack = _stack;
+   . = ALIGN(16);
+   _irq_stack_end = .;
+   . += _IRQ_STACK_SIZE;
+   __irq_stack = .;
+   _supervisor_stack_end = .;
+   . += _SUPERVISOR_STACK_SIZE;
+   . = ALIGN(16);
+   __supervisor_stack = .;
+   _abort_stack_end = .;
+   . += _ABORT_STACK_SIZE;
+   . = ALIGN(16);
+   __abort_stack = .;
+   _fiq_stack_end = .;
+   . += _FIQ_STACK_SIZE;
+   . = ALIGN(16);
+   __fiq_stack = .;
+   _undef_stack_end = .;
+   . += _UNDEF_STACK_SIZE;
+   . = ALIGN(16);
+   __undef_stack = .;
+} > psu_r5_btcm_MEM_0
+
+_end = .;
+}

--- a/examples/libmetal/machine/remote/amd_rpu/platform_init.c
+++ b/examples/libmetal/machine/remote/amd_rpu/platform_init.c
@@ -1,0 +1,459 @@
+/*
+ * Copyright (c) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <xparameters.h>
+#include <xil_cache.h>
+#include <xil_exception.h>
+#include <xstatus.h>
+#include <xscugic.h>
+#include <xreg_cortexr5.h>
+#include <xipipsu.h>
+#include <pm_api_sys.h>
+
+#include <metal/io.h>
+#include <metal/device.h>
+#include <metal/sys.h>
+#include <metal/irq.h>
+
+#include "common.h"
+
+#ifdef STDOUT_IS_16550
+ #include <xuartns550_l.h>
+
+ #define UART_BAUD 9600
+#endif
+
+/* Default generic I/O region page shift */
+/*
+ * Each I/O region can contain multiple pages. In FreeRTOS and bare-metal systems
+ * the memory mapping is flat with no virtual memory, so we assume a single page.
+ */
+#define DEFAULT_PAGE_SHIFT (-1UL)
+#define DEFAULT_PAGE_MASK  (-1UL)
+
+/**
+ * Definition of the interrupt controller will be provided by
+ * libmetal_xlnx_extention module
+ **/
+extern struct metal_irq_controller xlnx_irq_cntr;
+
+const metal_phys_addr_t metal_phys[] = {
+	IPI_BASE_ADDR, /**< base IPI address */
+	SHM_BASE_ADDR, /**< shared memory base address */
+	TTC0_BASE_ADDR, /**< base TTC0 address */
+};
+
+/*
+ * Define the metal device table for IPI, shared memory, and TTC devices. Linux
+ * uses device trees, but FreeRTOS relies on libmetal structures to describe the
+ * peripherals. Because these devices are memory mapped, we must expose their
+ * regions and interrupt information. The FreeRTOS memory map is flat, so the
+ * virtual and physical addresses are identical.
+ */
+static struct metal_device metal_dev_table[] = {
+	{
+		/* IPI device */
+		.name = IPI_DEV_NAME,
+		.bus = NULL,
+		.num_regions = 1,
+		.regions = {
+			{
+				.virt = (void *)IPI_BASE_ADDR,
+				.physmap = &metal_phys[0],
+				.size = 0x1000,
+				.page_shift = DEFAULT_PAGE_SHIFT,
+				.page_mask = DEFAULT_PAGE_MASK,
+				.mem_flags = DEVICE_NONSHARED | PRIV_RW_USER_RW,
+				.ops = {NULL},
+			}
+		},
+		.node = {NULL},
+		.irq_num = 1,
+		.irq_info = (void *)IPI_IRQ_VECT_ID,
+	},
+	{
+		/* Shared memory management device */
+		.name = SHM_DEV_NAME,
+		.bus = NULL,
+		.num_regions = 1,
+		.regions = {
+			{
+				.virt = (void *)SHM_BASE_ADDR,
+				.physmap = &metal_phys[1],
+				.size = 0x1000000,
+				.page_shift = DEFAULT_PAGE_SHIFT,
+				.page_mask = DEFAULT_PAGE_MASK,
+				.mem_flags = NORM_SHARED_NCACHE |
+						PRIV_RW_USER_RW,
+				.ops = {NULL},
+			}
+		},
+		.node = {NULL},
+		.irq_num = 0,
+		.irq_info = NULL,
+	},
+	{
+		/* ttc0 */
+		.name = TTC_DEV_NAME,
+		.bus = NULL,
+		.num_regions = 1,
+		.regions = {
+			{
+				.virt = (void *)TTC0_BASE_ADDR,
+				.physmap = &metal_phys[2],
+				.size = 0x1000,
+				.page_shift = DEFAULT_PAGE_SHIFT,
+				.page_mask = DEFAULT_PAGE_MASK,
+				.mem_flags = DEVICE_NONSHARED | PRIV_RW_USER_RW,
+				.ops = {NULL},
+			}
+		},
+		.node = {NULL},
+		.irq_num = 0,
+		.irq_info = NULL,
+	},
+};
+
+/**
+ * Extern global variables
+ */
+struct metal_device *ipi_dev = NULL;
+struct metal_device *shm_dev = NULL;
+struct metal_device *ttc_dev = NULL;
+
+/**
+ * @brief enable_caches() - Enable caches
+ */
+void enable_caches(void)
+{
+#ifdef __MICROBLAZE__
+#ifdef XPAR_MICROBLAZE_USE_ICACHE
+	Xil_ICacheEnable();
+#endif
+#ifdef XPAR_MICROBLAZE_USE_DCACHE
+	Xil_DCacheEnable();
+#endif
+#endif
+}
+
+/**
+ * @brief disable_caches() - Disable caches
+ */
+void disable_caches(void)
+{
+	Xil_DCacheDisable();
+	Xil_ICacheDisable();
+}
+
+/**
+ * @brief init_uart() - Initialize UARTs
+ */
+void init_uart(void)
+{
+#ifdef STDOUT_IS_16550
+	XUartNs550_SetBaud(STDOUT_BASEADDR, XPAR_XUARTNS550_CLOCK_HZ,
+			   UART_BAUD);
+	XUartNs550_SetLineControlReg(STDOUT_BASEADDR, XUN_LCR_8_DATA_BITS);
+#endif
+	/* Bootrom/BSP configures PS7/PSU UART to 115200 bps */
+}
+
+/**
+ * @brief default handler
+ */
+void xlnx_irq_isr(void *arg)
+{
+	unsigned int vector;
+
+	vector = (uintptr_t)arg;
+	if (vector >= (unsigned int)xlnx_irq_cntr.irq_num)
+		return;
+
+	(void)metal_irq_handle(xlnx_irq_cntr.irqs, (int)vector);
+}
+
+int metal_xlnx_irq_init(void)
+{
+	int ret;
+
+	ret =  metal_irq_register_controller(&xlnx_irq_cntr);
+	if (ret < 0) {
+		metal_log(METAL_LOG_ERROR, "%s: register irq controller failed.\n",
+			  __func__);
+		return ret;
+	}
+	return 0;
+}
+
+/**
+ * @brief platform_register_metal_device() - Statically Register libmetal
+ *        devices.
+ *        This function registers the IPI, shared memory and
+ *        TTC devices to the libmetal generic bus.
+ *        Libmetal uses bus structure to group the devices. Before you can
+ *        access the device with libmetal device operation, you will need to
+ *        register the device to a libmetal supported bus.
+ *        For non-Linux system, libmetal only supports "generic" bus, which is
+ *        used to manage the memory mapped devices.
+ *
+ * @return 0 - succeeded, non-zero for failures.
+ */
+int platform_register_metal_device(void)
+{
+	unsigned int i;
+	int ret;
+	struct metal_device *dev;
+
+	for (i = 0; i < sizeof(metal_dev_table) / sizeof(struct metal_device);
+	     i++) {
+		dev = &metal_dev_table[i];
+		metal_info("HOST: registering: %d, name=%s\n", i, dev->name);
+		ret = metal_register_generic_device(dev);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+
+/**
+ * @brief open_metal_devices() - Open registered libmetal devices.
+ *        This function opens all the registered libmetal devices.
+ *
+ * @return 0 - succeeded, non-zero for failures.
+ */
+int open_metal_devices(void)
+{
+	int ret;
+
+	/* Open shared memory device */
+	ret = metal_device_open(BUS_NAME, SHM_DEV_NAME, &shm_dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", SHM_DEV_NAME);
+		goto out;
+	}
+
+	/* Open IPI device */
+	ret = metal_device_open(BUS_NAME, IPI_DEV_NAME, &ipi_dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", IPI_DEV_NAME);
+		goto out;
+	}
+
+	/* Open TTC device */
+	ret = metal_device_open(BUS_NAME, TTC_DEV_NAME, &ttc_dev);
+	if (ret) {
+		metal_err("HOST: Failed to open device %s.\n", TTC_DEV_NAME);
+		goto out;
+	}
+
+out:
+	return ret;
+}
+
+/**
+ * @brief close_metal_devices() - close libmetal devices
+ *        This function closes all the libmetal devices which have
+ *        been opened.
+ *
+ */
+void close_metal_devices(void)
+{
+	/* Close shared memory device */
+	if (shm_dev)
+		metal_device_close(shm_dev);
+
+	/* Close IPI device */
+	if (ipi_dev)
+		metal_device_close(ipi_dev);
+
+	/* Close TTC device */
+	if (ttc_dev)
+		metal_device_close(ttc_dev);
+}
+
+static XStatus init_ttc(void)
+{
+	XPm_NodeStatus NodeStatus = {0};
+	XIpiPsu_Config *IpiCfgPtr;
+	XIpiPsu IpiInst;
+
+	/* Look Up the config data */
+	IpiCfgPtr = XIpiPsu_LookupConfig(XPAR_XIPIPSU_0_BASEADDR);
+	if (!IpiCfgPtr) {
+		metal_err("HOST: %s ERROR in getting CfgPtr\n", __func__);
+		return -EINVAL;
+	}
+
+	/* Init with the Cfg Data */
+	if (XIpiPsu_CfgInitialize(&IpiInst, IpiCfgPtr, IpiCfgPtr->BaseAddress) != XST_SUCCESS) {
+		metal_err("HOST: Unable to configure IPI Instance for xilpm\n");
+		return -EINVAL;
+	}
+
+	if (XPm_InitXilpm(&IpiInst) != XST_SUCCESS) {
+		metal_err("HOST: Failed to init xilpm\n");
+		return -EINVAL;
+	}
+
+	if (XPm_GetNodeStatus(TTC_NODEID, &NodeStatus) != XST_SUCCESS) {
+		metal_err("HOST: XPm_GetNodeStatus failed\n");
+		return -EINVAL;
+	}
+
+	/*
+	 * If node status is 1, then TTC is powered on.
+	 * Else attempt to power on TTC.
+	 */
+	if (!NodeStatus.status == 0 &&
+	    XPm_RequestNode(TTC_NODEID, PM_CAP_ACCESS, 100, 0) != XST_SUCCESS) {
+		metal_err("HOST: TTC device was powered off. Attempt to power on failed.\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief ipi_irq_handler() - IPI interrupt handler
+ *        It will clear the notified flag to mark it's got an IPI interrupt.
+ *        It will stop the RPU->APU timer and will clear the notified
+ *        flag to mark it's got an IPI interrupt
+ *
+ * @param[in] ch - channel to use
+ *
+ * @return - If the IPI interrupt is triggered by its remote, it returns
+ *           METAL_IRQ_HANDLED. It returns METAL_IRQ_NOT_HANDLED, if it is
+ *           not the interrupt it expected.
+ *
+ */
+static inline int ipi_irq_handler(int vect_id, void *priv)
+{
+	struct channel_s *ch = (struct channel_s *)priv;
+	uint32_t val;
+
+	metal_assert(ch);
+
+	(void)vect_id;
+
+	if (ch) {
+		val = metal_io_read32(ch->ipi_io, IPI_ISR_OFFSET);
+		if (val & ch->ipi_mask) {
+			/* stop RPU -> APU timer */
+			if (ch->ttc_io) {
+				stop_timer(ch->ttc_io, TTC_CNT_APU_TO_RPU);
+				metal_io_write32(ch->ipi_io, IPI_ISR_OFFSET, ch->ipi_mask);
+				system_resume(ch);
+				return METAL_IRQ_HANDLED;
+			}
+		}
+	}
+	return METAL_IRQ_NOT_HANDLED;
+}
+
+/**
+ * @brief platform_init() - Register libmetal devices.
+ *        This function register the libmetal generic bus, and then
+ *        register the IPI, shared memory descriptor and shared memory
+ *        devices to the libmetal generic bus.
+ *
+ * @return 0 - succeeded, non-zero for failures.
+ */
+int platform_init(struct channel_s *ch)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	struct metal_io_region *io = NULL;
+	int ret;
+
+	enable_caches();
+	init_uart();
+
+	if (init_irq()) {
+		metal_err("HOST: Failed to initialize interrupt\n");
+		return XST_FAILURE;
+	}
+
+	if (init_ttc() != XST_SUCCESS) {
+		metal_err("HOST: Failed to init IPI for xilpm\n");
+		return XST_FAILURE;
+	}
+
+	/* Initialize libmetal environment */
+	metal_init(&metal_param);
+
+	/* Initialize metal Xilinx IRQ controller */
+	ret = metal_xlnx_irq_init();
+	if (ret) {
+		metal_err("HOST: %s: Xilinx metal IRQ controller init failed.\n", __func__);
+		return ret;
+	}
+
+	/* Register libmetal devices */
+	ret = platform_register_metal_device();
+	if (ret) {
+		metal_err("HOST: %s: failed to register devices: %d\n", __func__, ret);
+		return ret;
+	}
+
+	/* Open libmetal devices which have been registered */
+	ret = open_metal_devices();
+	if (ret) {
+		metal_err("HOST: %s: failed to open devices: %d\n", __func__, ret);
+		return ret;
+	}
+
+	/* wipe pending interrupts */
+	io = metal_device_io_region(ipi_dev, 0);
+	if (!io) {
+		metal_err("HOST: Failed to map io region for %s.\n", ipi_dev->name);
+	} else {
+		/* disable IPI interrupt */
+		metal_io_write32(io, IPI_IDR_OFFSET, IPI_MASK);
+		/* clear old IPI interrupt */
+		metal_io_write32(io, IPI_ISR_OFFSET, IPI_MASK);
+	}
+
+	ch->ipi_io = io;
+	ch->ipi_mask = IPI_MASK;
+
+	/*
+	 * Buffer clean up. Do this at start in case a
+	 * previous run was stopped midway.
+	 */
+	io = metal_device_io_region(shm_dev, 0);
+	if (!io)
+		metal_err("HOST: Failed to map io region for %s.\n", shm_dev->name);
+	else
+		metal_io_block_set(io, 0, 0, 0x400000);
+
+	ch->shm_io = io;
+
+	/* Get TTC IO region */
+	ch->ttc_io = metal_device_io_region(ttc_dev, 0);
+	if (!ch->ttc_io) {
+		metal_err("HOST: Failed to map io region for %s.\n", ttc_dev->name);
+		return -ENODEV;
+	}
+
+	/* Get the IPI IRQ from the opened IPI device */
+	ch->irq_vector_id = (intptr_t)ipi_dev->irq_info;
+
+	/* Register IPI irq handler */
+	metal_irq_register(ch->irq_vector_id, ipi_irq_handler, ch);
+
+	return 0;
+}
+
+void platform_cleanup(struct channel_s *ch)
+{
+	metal_irq_unregister(ch->irq_vector_id);
+	memset(&ch, 0, sizeof(ch));
+
+	/* Close libmetal devices which have been opened */
+	close_metal_devices();
+	/* Finish libmetal environment */
+	metal_finish();
+	disable_caches();
+}

--- a/examples/libmetal/machine/remote/amd_rpu/platform_init.h
+++ b/examples/libmetal/machine/remote/amd_rpu/platform_init.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017-2022 Xilinx, Inc.  All rights reserved.
+ * Copyright (c) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __PLATFORM_INIT_H__
+#define __PLATFORM_INIT_H__
+
+struct channel_s;
+
+/**
+ * @brief platform_init() - Register libmetal devices.
+ *        This function register the libmetal generic bus, and then
+ *        register the IPI, shared memory descriptor and shared memory
+ *        devices to the libmetal generic bus.
+ *
+ * @return 0 - succeeded, non-zero for failures.
+ */
+int platform_init(struct channel_s *ch);
+
+/**
+ * @brief platform_cleanup() - system cleanup
+ *        This function finish the libmetal environment
+ *        and disable caches.
+ *
+ * @return 0 - succeeded, non-zero for failures.
+ */
+void platform_cleanup(struct channel_s *ch);
+
+/**
+ * @brief init_irq() - Initialize GIC and connect IPI interrupt
+ *        This function will initialize the GIC and connect the IPI
+ *        interrupt.
+ *
+ * @return 0 - succeeded, non-0 for failures
+ */
+int init_irq(void);
+
+#endif /* __PLATFORM_INIT_H__ */

--- a/examples/libmetal/machine/remote/amd_rpu/system/CMakeLists.txt
+++ b/examples/libmetal/machine/remote/amd_rpu/system/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SYSTEM}/CMakeLists.txt")
+  add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SYSTEM})
+endif (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_SYSTEM}/CMakeLists.txt")

--- a/examples/libmetal/machine/remote/amd_rpu/system/freertos/CMakeLists.txt
+++ b/examples/libmetal/machine/remote/amd_rpu/system/freertos/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+collect(PROJECT_LIB_DEPS freertos)
+collect (APP_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.c)
+collect (APP_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/gic_init.c)
+collect (PROJECT_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/examples/libmetal/machine/remote/amd_rpu/system/freertos/README.md
+++ b/examples/libmetal/machine/remote/amd_rpu/system/freertos/README.md
@@ -1,0 +1,15 @@
+# AMD RPU FreeRTOS System Port
+
+This directory contains the OS glue that lets the remote IRQ shared-memory demo
+run as a FreeRTOS task on the AMD RPU.
+
+- `main.c` creates the worker task and drives the FreeRTOS scheduler.
+- `gic_init.c` installs the IPI ISR using the FreeRTOS interrupt helpers.
+- `amp_demo_os.h` records the demo task handle so `system_suspend()` can call
+  `vTaskSuspend(NULL)` while `system_resume()` wakes it with
+  `xTaskResumeFromISR`, allowing the Idle task to run while the demo waits for
+  a kick.
+
+The top-level machine README covers configuration flags and build steps. When
+`PROJECT_SYSTEM=freertos`, CMake automatically pulls in the sources from this
+directory.

--- a/examples/libmetal/machine/remote/amd_rpu/system/freertos/amp_demo_os.h
+++ b/examples/libmetal/machine/remote/amd_rpu/system/freertos/amp_demo_os.h
@@ -1,0 +1,80 @@
+ /*
+  * Copyright (C) 2025, Advanced Micro Devices, Inc.
+  *
+  * SPDX-License-Identifier: BSD-3-Clause
+  */
+
+#ifndef __AMP_DEMO_OS_H__
+#define __AMP_DEMO_OS_H__
+
+#include <metal/atomic.h>
+#include <metal/assert.h>
+#include <metal/sys.h>
+#include <metal/cpu.h>
+
+#include <FreeRTOS.h>
+#include <task.h>
+#include "portmacro.h"
+
+#include "xil_printf.h"
+
+struct channel_s {
+	struct metal_io_region *ipi_io; /* IPI metal i/o region */
+	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
+	struct metal_io_region *ttc_io; /* TTC metal i/o region */
+	uint32_t ipi_mask; /* RPU IPI mask */
+	TaskHandle_t task; /* Demo task handle used for suspend/resume. */
+	int irq_vector_id; /* IRQ number. */
+};
+
+/**
+ * @brief amp_os_init() - set OS specific information in the channel
+ *
+ * @param[in] ch - channel to store task
+ * @param[in] arg - task to use in demos
+ */
+static inline int amp_os_init(struct channel_s *ch, void *arg)
+{
+	TaskHandle_t task = (TaskHandle_t)arg;
+
+	metal_assert(ch);
+	metal_assert(task);
+
+	ch->task = task;
+
+	return 0;
+}
+
+/**
+ * @brief system_suspend() - suspend the channel's execution
+ *
+ * @param[in] ch - channel with task to suspend
+ */
+static inline void system_suspend(struct channel_s *ch)
+{
+	metal_assert(ch);
+
+	/* Suspend this task until the ISR resumes it. */
+	vTaskSuspend(NULL);
+}
+
+/**
+ * @brief system_resume - This routine will wake the demo task
+ *
+ * For AMD Implementation, the suspended task needs to be resumed
+ * and the scheduler needs an explicit signal for context switch. Call
+ * that in this routine.
+ * @param[in] ch - channel with task to wake
+ */
+static inline void system_resume(struct channel_s *ch)
+{
+	BaseType_t yield_required;
+
+	metal_assert(ch);
+	metal_assert(ch->task);
+
+	yield_required = xTaskResumeFromISR(ch->task);
+	portYIELD_FROM_ISR(yield_required);
+}
+
+#endif /* __AMP_DEMO_OS_H__ */

--- a/examples/libmetal/machine/remote/amd_rpu/system/freertos/gic_init.c
+++ b/examples/libmetal/machine/remote/amd_rpu/system/freertos/gic_init.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014, Mentor Graphics Corporation
+ * All rights reserved.
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "xparameters.h"
+#include "xil_exception.h"
+#include "xil_printf.h"
+#include "xscugic.h"
+#include <metal/sys.h>
+#include <metal/irq.h>
+#include "FreeRTOS.h"
+#include "common.h"
+
+extern void xlnx_irq_isr(void *arg);
+
+/* Interrupt Controller setup */
+int init_irq(void)
+{
+	/*
+	 * Register the ISR with the interrupt controller instance
+	 * initialized by porting layer.
+	 */
+	xPortInstallInterruptHandler(IPI_IRQ_VECT_ID,
+				     (Xil_ExceptionHandler)xlnx_irq_isr,
+				     (void *)IPI_IRQ_VECT_ID);
+	return 0;
+}

--- a/examples/libmetal/machine/remote/amd_rpu/system/freertos/main.c
+++ b/examples/libmetal/machine/remote/amd_rpu/system/freertos/main.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * main.c
+ *
+ * This file wires the FreeRTOS task runner to invoke the demo entry point.
+ */
+
+#include "common.h"
+
+static TaskHandle_t comm_task;
+
+/**
+ * @brief    demo application main processing task
+ *           Here are the steps for the main function:
+ *           * Run the libmetal demo
+ *           * self killing task.
+ * @return   0 - succeeded, non-zero for failures.
+ */
+static void processing(void *unused_arg)
+{
+	(void)unused_arg;
+
+	demo((void *)comm_task);
+
+	/* Terminate this task */
+	vTaskDelete(NULL);
+}
+
+/**
+ * @brief    main function of the demo application.
+ *           It starts the processing task and go wait forever.
+ * @return   0 - succeeded, but in reality will never return.
+ */
+
+int main(void)
+{
+	BaseType_t stat;
+
+	Xil_ExceptionDisable();
+
+	/* Create the tasks */
+	stat = xTaskCreate(processing, (const char *)"HW",
+				1024, NULL, 2, &comm_task);
+	if (stat != pdPASS) {
+		metal_err("REMOTE: Cannot create task\n");
+	} else {
+		/* Start running FreeRTOS tasks */
+		vTaskStartScheduler();
+	}
+
+	/*
+	 * If all is well, the scheduler will now be running, and the
+	 * following line will never be reached.  If the following
+	 * line does execute, then there was insufficient FreeRTOS heap
+	 * memory available for the idle and/or timer tasks to be created.
+	 * See the memory management section on the FreeRTOS web site
+	 * for more details.
+	 */
+	for ( ;; );
+
+	/* suppress compilation warnings*/
+	return 0;
+}


### PR DESCRIPTION
This PR replaces work done in https://github.com/OpenAMP/openamp-system-reference/pull/21 

This PR adds libmetal AMP demo support for Remote on AMD-RPU running with baremetal or FreeRTOS and Linux host AMP demo to communicate with this.