### PR TITLE
examples: legacy_apps: xlnx: Remove xlnx_hw_to_bsp_irq()

### DIFF
--- a/examples/legacy_apps/machine/xlnx/README.md
+++ b/examples/legacy_apps/machine/xlnx/README.md
@@ -1,23 +1,36 @@
 # Steps to generate inputs for AMD-Xilinx RPU Firmware Demos
 
-Dependencies:
-1. Lopper : https://github.com/devicetree-org/lopper.git
-2. System Device Tree generated from design : https://docs.amd.com/r/en-US/ug1647-porting-embeddedsw-components/Generating-a-System-Device-Tree-Using-SDTGen
+Below is sample run for SOM KV260 platform
 
-Below is sample run for Versal Gen 1 platform
-## Generate OpenAMP RPU Device Tree
+## Pick up System Device Tree
 
+```sh
+wget https://edf.amd.com/sswreleases/rel-v2025.2/sdt/2025.2/2025.2_1115_1_11150857/external/k26-smk-kv-sdt/k26-smk-kv-sdt_2025.2_1115_1_11150857.tar.gz
+tar xvf k26-smk-kv-sdt_2025.2_1115_1_11150857.tar.gz
+export SDT=$PWD/k26-smk-kv-sdt_2025.2_1115_1_11150857/system-top.dts
+```
+
+## Set up Lopper
+
+```sh
+git clone https://github.com/devicetree-org/lopper.git
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -r lopper/requirements.txt
+pip3 install lopper
+
+export LOPPER_PY=$PWD/lopper/lopper.py
+```
+
+## Apply Domain YAML to System Device Tree
 SDT is the System Device Tree generated from design
+
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
+python3 $LOPPER_PY -f --enhanced   -x '*.yaml' -i $YAML $SDT yaml_applied.dts
+python3 $LOPPER_PY -f --enhanced yaml_applied.dts rpu.dts -- gen_domain_dts psu_cortexr5_0   --openamp_no_header
 
-python3 lopper.py -f --enhanced \
-  -x '*.yaml' \
-  -i $YAML $SDT yaml_applied.dts
-
-python3 lopper.py -f --enhanced \
-  yaml_applied.dts rpu.dts \
-  -- gen_domain_dts psu_cortexr5_0   --openamp_no_header
+export RPU_DTS=$PWD/rpu.dts
 ```
 The above Device Tree "rpu.dts" will be used for configuration of the app's interrupts, shared memory and linker script.
 
@@ -25,14 +38,8 @@ The above Device Tree "rpu.dts" will be used for configuration of the app's inte
 
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
-export CONFIG_DTFILE=rpu.dts
-
-cd openamp-system-reference/examples/legacy_apps/machine/zynqmp_r5
-python3 lopper.py -O -f -v --enhanced  --permissive \
-  -O . ${CONFIG_DTFILE} -- openamp --openamp_header_only \
-  --openamp_output_filename=amd_platform_info.h \
-  --openamp_remote=psv_cortexr5_0
-cd -
+python3 lopper.py -O -f --enhanced  --permissive  -O . ${RPU_DTS} -- openamp --openamp_header_only \
+ --openamp_output_filename=amd_platform_info.h --openamp_remote=psu_cortexr5_0
 ```
 The output amd_platform_info.h needs to be in the location denoted above of "openamp-system-reference/examples/legacy_apps/machine/zynqmp_r5" BEFORE
 cmake configure step.
@@ -41,8 +48,6 @@ cmake configure step.
 
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
-export CONFIG_DTFILE=rpu.dts
-python3 lopper.py -O ${S} rpu.dts \
-  -- baremetallinker_xlnx psv_cortexr5_0 <output location> openamp
+python3 lopper.py -O . $RPU_DTS -- baremetallinker_xlnx psu_cortexr5_0 . openamp
 ```
 The RPU Application Linker config object needs to be pointed to with cmake variable LINKER_METADATA_FILE at cmake configure step.

--- a/examples/legacy_apps/machine/xlnx/README.md
+++ b/examples/legacy_apps/machine/xlnx/README.md
@@ -1,23 +1,48 @@
 # Steps to generate inputs for AMD-Xilinx RPU Firmware Demos
 
-Dependencies:
-1. Lopper : https://github.com/devicetree-org/lopper.git
-2. System Device Tree generated from design : https://docs.amd.com/r/en-US/ug1647-porting-embeddedsw-components/Generating-a-System-Device-Tree-Using-SDTGen
+Below is sample run for SOM KV260 platform
 
-Below is sample run for Versal Gen 1 platform
-## Generate OpenAMP RPU Device Tree
+## Pick up Domain YAMLs
 
+```sh
+git clone https://github.com/Xilinx/meta-xilinx.git -b rel-v2026.1
+export OPENAMP_OVERLAY_YAML=$PWD/meta-xilinx/meta-xilinx-standalone-sdt/conf/domainyaml/zynqmp-openamp-overlay.yaml
+export BASE_YAML=$PWD/meta-xilinx/meta-xilinx-standalone-sdt/conf/domainyaml/zynqmp-multidomain-base.yaml
+```
+
+## Pick up System Device Tree
+
+```sh
+wget https://edf.amd.com/sswreleases/rel-v2026.1/sdt/2026.1/2026.1_0609_1_06092108/external/k26-smk-kv-sdt/k26-smk-kv-sdt_2026.1_0609_1_06092108.tar.gz
+tar xvf k26-smk-kv-sdt_2026.1_0609_1_06092108.tar.gz
+export SDT=$PWD/k26-smk-kv-sdt_2026.1_0609_1_06092108/system-top.dts
+
+```
+
+## Set up Lopper
+
+```sh
+git clone https://github.com/devicetree-org/lopper.git -b master
+
+cd lopper
+git checkout d12bd4e28388d193512a3e573b7baad69783984c -b system_ref_demo
+cd -
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -r lopper/requirements.txt
+pip3 install lopper
+
+export LOPPER_PY=$PWD/lopper/lopper.py
+```
+
+## Apply Domain YAML to System Device Tree
 SDT is the System Device Tree generated from design
+
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
-
-python3 lopper.py -f --enhanced \
-  -x '*.yaml' \
-  -i $YAML $SDT yaml_applied.dts
-
-python3 lopper.py -f --enhanced \
-  yaml_applied.dts rpu.dts \
-  -- gen_domain_dts psu_cortexr5_0   --openamp_no_header
+python3 $LOPPER_PY -f --enhanced   -x '*.yaml' -i $BASE_YAML -i $OPENAMP_OVERLAY_YAML $SDT rpu.dts
+export RPU_DTS=$PWD/rpu.dts
 ```
 The above Device Tree "rpu.dts" will be used for configuration of the app's interrupts, shared memory and linker script.
 
@@ -25,14 +50,8 @@ The above Device Tree "rpu.dts" will be used for configuration of the app's inte
 
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
-export CONFIG_DTFILE=rpu.dts
-
-cd openamp-system-reference/examples/legacy_apps/machine/zynqmp_r5
-python3 lopper.py -O -f -v --enhanced  --permissive \
-  -O . ${CONFIG_DTFILE} -- openamp --openamp_header_only \
-  --openamp_output_filename=amd_platform_info.h \
-  --openamp_remote=psv_cortexr5_0
-cd -
+python3 $LOPPER_PY --enhanced  --permissive  -O . ${RPU_DTS} -- openamp --openamp_header_only \
+ --openamp_output_filename=amd_platform_info.h --openamp_remote=psu_cortexr5_0
 ```
 The output amd_platform_info.h needs to be in the location denoted above of "openamp-system-reference/examples/legacy_apps/machine/zynqmp_r5" BEFORE
 cmake configure step.
@@ -41,8 +60,30 @@ cmake configure step.
 
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
-export CONFIG_DTFILE=rpu.dts
-python3 lopper.py -O ${S} rpu.dts \
-  -- baremetallinker_xlnx psv_cortexr5_0 <output location> openamp
+python3 $LOPPER_PY -O . $RPU_DTS -- baremetallinker_xlnx psu_cortexr5_0 . openamp
 ```
 The RPU Application Linker config object needs to be pointed to with cmake variable LINKER_METADATA_FILE at cmake configure step.
+
+## Generate Linux Device Tree with OpenAMP Nodes
+
+Generate the OpenAMP-processed System Device Tree for the APU, then prune it to the Linux domain. This uses `rpu.dts`, which already contains the domain and OpenAMP YAML content applied above.
+
+```sh
+export LOPPER_DTC_FLAGS="-b 0 -@"
+export APU_PROCESSOR=psu_cortexa53_0
+export LINUX_OPENAMP_OUTPUT=$PWD/linux-openamp
+export LOPPER_ROOT=$(dirname "$LOPPER_PY")
+mkdir -p "$LINUX_OPENAMP_OUTPUT"
+
+python3 "$LOPPER_PY" -O "$LINUX_OPENAMP_OUTPUT" -f --enhanced \
+ "$RPU_DTS" "$LINUX_OPENAMP_OUTPUT/$APU_PROCESSOR-openamp.dts" \
+ -- openamp "$APU_PROCESSOR" linux_dt
+
+python3 "$LOPPER_PY" -O "$LINUX_OPENAMP_OUTPUT" -f --enhanced \
+ -i "$LOPPER_ROOT/lopper/lops/lop-a53-imux.dts" \
+ "$LINUX_OPENAMP_OUTPUT/$APU_PROCESSOR-openamp.dts" \
+ "$LINUX_OPENAMP_OUTPUT/cortexa53-linux-openamp.dts" \
+ -- gen_domain_dts "$APU_PROCESSOR" linux_dt
+```
+
+The generated Linux Device Tree with the OpenAMP remoteproc and reserved-memory nodes is `linux-openamp/cortexa53-linux-openamp.dts`.

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/freertos/gic_init.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/freertos/gic_init.c
@@ -17,13 +17,6 @@
 #include "xparameters.h"
 #include "xscugic.h"
 
-#define FREERTOS_BSP_IRQ_OFFSET 32
-
-int xlnx_hw_to_bsp_irq(int sys_irq)
-{
-	return sys_irq - FREERTOS_BSP_IRQ_OFFSET;
-}
-
 /* Interrupt Controller setup */
 int system_interrupt_register(int int_num, void (*intr_handler)(void *),
 			      void *data)

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/generic/gic_init.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/generic/gic_init.c
@@ -21,11 +21,6 @@
 
 static XScuGic xInterruptController;
 
-int xlnx_hw_to_bsp_irq(int sys_irq)
-{
-	return sys_irq;
-}
-
 int system_interrupt_register(int intr_num, void (*intr_handler)(void *),
 			      void *data)
 {

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
@@ -179,8 +179,6 @@ extern struct metal_irq_controller xlnx_irq_cntr;
 int system_interrupt_register(int int_num, void (*intr_handler)(void *),
 			      void *data);
 
-int xlnx_hw_to_bsp_irq(int sys_irq);
-
 /* RPMsg virtio shared buffer pool */
 static struct rpmsg_virtio_shm_pool shpool;
 
@@ -262,10 +260,6 @@ static int xlnx_machine_init(void)
 	}
 
 	metal_dbg("kick device irq id = %d\n", (int)kick_device.irq_info);
-
-	/* convert from HW irq number to bsp specific irq */
-	kick_device.irq_info =
-		(void *)xlnx_hw_to_bsp_irq((int)kick_device.irq_info);
 
 	ret = system_interrupt_register((int)kick_device.irq_info,
 					xlnx_irq_isr,

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
@@ -179,8 +179,6 @@ extern struct metal_irq_controller xlnx_irq_cntr;
 int system_interrupt_register(int int_num, void (*intr_handler)(void *),
 			      void *data);
 
-int xlnx_hw_to_bsp_irq(int sys_irq);
-
 /* RPMsg virtio shared buffer pool */
 static struct rpmsg_virtio_shm_pool shpool;
 
@@ -323,10 +321,6 @@ static int xlnx_machine_init(void)
 	}
 
 	metal_dbg("kick device irq id = %d\n", (int)kick_device.irq_info);
-
-	/* convert from HW irq number to bsp specific irq */
-	kick_device.irq_info =
-		(void *)xlnx_hw_to_bsp_irq((int)kick_device.irq_info);
 
 	ret = system_interrupt_register((int)kick_device.irq_info,
 					xlnx_irq_isr,


### PR DESCRIPTION
The Lopper-generated amd_platform_info.h already accounts for BSP. So remove the unneeded function xlnx_hw_to_bsp_irq() which tries to account for IRQ system number difference from baremetal (generic) and FreeRTOS BSPs.