### PR TITLE
Feature/remove toc not included warnings

### DIFF
--- a/examples/legacy_apps/README.md
+++ b/examples/legacy_apps/README.md
@@ -50,19 +50,3 @@ export PROJECT_ROOT=$PWD
 -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
   $ make -C build VERBOSE=1 install
 ```
-
-## Run application on a Linux PC
-It is possible to run application on a Linux PC to communicate between two Linux processes.
-
-```shell
-  $ cd $PROJECT_ROOT/target
-  $ echo "################### run ping test #####################"
-  $ LD_LIBRARY_PATH=./lib  ./bin/rpmsg-echo-static &
-  $ sleep 1
-  $ LD_LIBRARY_PATH=./lib  ./bin//msg-test-rpmsg-ping-static 1
-
-  $ echo "################### run ping test #####################"
-  $ LD_LIBRARY_PATH=./lib  ./bin/rpmsg-nocopy-echo-static &
-  $ sleep 1
-  $ LD_LIBRARY_PATH=./lib  ./bin//rpmsg-nocopy-ping-static  1
-```

--- a/examples/legacy_apps/README.md
+++ b/examples/legacy_apps/README.md
@@ -24,29 +24,29 @@ west update
 
 The following steps are to build legacy apps on a host machine.
 
-```
+```shell
 export PROJECT_ROOT=$PWD
 ```
 
 ## Build libmetal
 ```shell
-  $ cd $PROJECT_ROOT/libmetal
-  $ cmake . -Bbuild -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
-  $ make -C build VERBOSE=1 install
+cd $PROJECT_ROOT/libmetal
+cmake . -Bbuild -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
+make -C build VERBOSE=1 install
 ```
 
 ## Build open_amp
 ```shell
-  $ cd $PROJECT_ROOT/open-amp
-  $ cmake . -Bbuild -DCMAKE_INCLUDE_PATH=$PROJECT_ROOT/libmetal/build/lib/include/   -DCMAKE_LIBRARY_PATH=$PROJECT_ROOT/libmetal/build/lib/ -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
-  $ make -C build VERBOSE=1 install
+cd $PROJECT_ROOT/open-amp
+cmake . -Bbuild -DCMAKE_INCLUDE_PATH=$PROJECT_ROOT/libmetal/build/lib/include/   -DCMAKE_LIBRARY_PATH=$PROJECT_ROOT/libmetal/build/lib/ -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
+make -C build VERBOSE=1 install
 ```
 ## Build legacy Apps
 ```shell
-  $ cd $PROJECT_ROOT/openamp-system-reference/examples/legacy_apps
-  $ cmake -Bbuild \
+cd $PROJECT_ROOT/openamp-system-reference/examples/legacy_apps
+cmake -Bbuild \
 -DCMAKE_INCLUDE_PATH="$PROJECT_ROOT/libmetal/build/lib/include/;$PROJECT_ROOT/open-amp/build/lib/include/" \
 -DCMAKE_LIBRARY_PATH="$PROJECT_ROOT/libmetal/build/lib/;$PROJECT_ROOT/open-amp/build/lib/" \
 -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
-  $ make -C build VERBOSE=1 install
+make -C build VERBOSE=1 install
 ```

--- a/examples/legacy_apps/README.md
+++ b/examples/legacy_apps/README.md
@@ -1,4 +1,4 @@
-# Build Overview
+# System Reference Legacy Apps Build Overview
 
 This page details how to setup and build the
 [OpenAMP System Reference](https://github.com/OpenAMP/openamp-system-reference/) legacy apps
@@ -6,7 +6,7 @@ and test examples found in the examples/legacy_apps directory.
 These applications were moved from the [OpenAMP repository](https://github.com/OpenAMP/open-amp).
 
 
-# Initialization
+## Initialization
 
 The first step is to initialize the workspace folder (``my-workspace``) where
 the examples and all Zephyr modules will be cloned. You can do
@@ -20,7 +20,7 @@ cd my-workspace
 west update
 ```
 
-# Build
+## Build
 
 The following steps are to build legacy apps on a host machine.
 
@@ -28,20 +28,20 @@ The following steps are to build legacy apps on a host machine.
 export PROJECT_ROOT=$PWD
 ```
 
-## Build libmetal
+### Build libmetal
 ```shell
 cd $PROJECT_ROOT/libmetal
 cmake . -Bbuild -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
 make -C build VERBOSE=1 install
 ```
 
-## Build open_amp
+### Build open_amp
 ```shell
 cd $PROJECT_ROOT/open-amp
 cmake . -Bbuild -DCMAKE_INCLUDE_PATH=$PROJECT_ROOT/libmetal/build/lib/include/   -DCMAKE_LIBRARY_PATH=$PROJECT_ROOT/libmetal/build/lib/ -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target
 make -C build VERBOSE=1 install
 ```
-## Build legacy Apps
+### Build legacy Apps
 ```shell
 cd $PROJECT_ROOT/openamp-system-reference/examples/legacy_apps
 cmake -Bbuild \

--- a/examples/legacy_apps/README.md
+++ b/examples/legacy_apps/README.md
@@ -1,7 +1,9 @@
-# Summary
+# Build Overview
 
-This directory contains legacy applications and tests examples.
-These applications were moved from open-amp repository.
+This page details how to setup and build the
+[OpenAMP System Reference](https://github.com/OpenAMP/openamp-system-reference/) legacy apps
+and test examples found in the examples/legacy_apps directory.
+These applications were moved from the [OpenAMP repository](https://github.com/OpenAMP/open-amp).
 
 
 # Initialization
@@ -20,7 +22,7 @@ west update
 
 # Build
 
-Following steps to build legacy apps on host machine.
+The following steps are to build legacy apps on a host machine.
 
 ```
 export PROJECT_ROOT=$PWD

--- a/examples/legacy_apps/examples/echo/README.rst
+++ b/examples/legacy_apps/examples/echo/README.rst
@@ -8,7 +8,11 @@ back the message. The processor that sends the message will verify the echoed me
 Compilation
 ***********
 
-See `README.md <../../README.md>`_ for details.
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+
+If you are perusing the github repository refer to the `legacy_apps README.md <../../README.md>`_
+for compilation information.
 
 Run demonstration on a Linux PC
 *******************************

--- a/examples/legacy_apps/examples/linux_rpc_demo/README.rst
+++ b/examples/legacy_apps/examples/linux_rpc_demo/README.rst
@@ -1,3 +1,6 @@
+Overview
+********
+
 This readme is about the OpenAMP linux_rpc_demo.
 
 The linux_rpc_demo is about remote procedure calls between linux host and a linux
@@ -9,7 +12,11 @@ Compilation
 ***********
 Add cmake option `-DWITH_PROXY_APPS=ON` to build the system reference demonstration applications.
 
-See `README.md <../../README.md>`_ for details.
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+
+If you are perusing the github repository refer to the `legacy_apps README.md <../../README.md>`_
+for compilation information.
 
 Run demonstration on a Linux PC
 *******************************
@@ -31,7 +38,7 @@ Run demonstration on a Linux PC
 Enter the inputs on the host side the same gets printed on the remote side. You will see
 communication between the host and remote process using rpmsg calls.
 
-Note:
-*****
-`sudo` is required to run the OpenAMP demos between Linux processes, as it doesn't work on
-some systems if you are normal users.
+.. note::
+
+   `sudo` is required to run the OpenAMP demos between Linux processes, as it doesn't work on
+   some systems if you are normal users.

--- a/examples/legacy_apps/examples/matrix_multiply/README.rst
+++ b/examples/legacy_apps/examples/matrix_multiply/README.rst
@@ -8,7 +8,11 @@ The other processor calculates the matrix multiplication and returns the result 
 Compilation
 ***********
 
-See `README.md <../../README.md>`_ for details.
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+
+If you are perusing the github repository refer to the `legacy_apps README.md <../../README.md>`_
+for compilation information.
 
 Run demonstration on a Linux PC
 *******************************

--- a/examples/legacy_apps/examples/rpc_demo/README.rst
+++ b/examples/legacy_apps/examples/rpc_demo/README.rst
@@ -1,3 +1,6 @@
+Overview
+********
+
 This readme is about the OpenAMP rpc_demo demo.
 The rpc_demo is about one processor uses the UART on the other processor and creates file on
 the other processor's filesystem with file operations.
@@ -19,7 +22,13 @@ Here is an example to generate the to generate the `rpc_demo` application:
 
     cmake -DCMAKE_TOOLCHAIN_FILE=zynqmp_r5_generic -DWITH_APPS=ON -DWITH_PROXY=ON
 
-See `README.md <../../README.md>`_ to generate the `rpc_demod` application.
+
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+
+If you are perusing the github repository refer to the `legacy_apps README.md <../../README.md>`_
+for compilation information.
+
 
 Linux Compilation
 =================

--- a/examples/legacy_apps/machine/xlnx/README.md
+++ b/examples/legacy_apps/machine/xlnx/README.md
@@ -5,7 +5,7 @@ Dependencies:
 2. System Device Tree generated from design : https://docs.amd.com/r/en-US/ug1647-porting-embeddedsw-components/Generating-a-System-Device-Tree-Using-SDTGen
 
 Below is sample run for Versal Gen 1 platform
-### Generate OpenAMP RPU Device Tree
+## Generate OpenAMP RPU Device Tree
 
 SDT is the System Device Tree generated from design
 ```sh
@@ -21,7 +21,7 @@ python3 lopper.py -f --enhanced \
 ```
 The above Device Tree "rpu.dts" will be used for configuration of the app's interrupts, shared memory and linker script.
 
-### Generate OpenAMP App config header
+## Generate OpenAMP App config header
 
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"
@@ -37,7 +37,7 @@ cd -
 The output amd_platform_info.h needs to be in the location denoted above of "openamp-system-reference/examples/legacy_apps/machine/zynqmp_r5" BEFORE
 cmake configure step.
 
-### Generate RPU Application Linker config object
+## Generate RPU Application Linker config object
 
 ```sh
 export LOPPER_DTC_FLAGS="-b 0 -@"

--- a/examples/libmetal/machine/remote/amd_rpu/system/generic/README.md
+++ b/examples/libmetal/machine/remote/amd_rpu/system/generic/README.md
@@ -1,4 +1,5 @@
 AMD RPU Baremetal System Port
+=============================
 
 This directory holds the minimal OS layer that lets the remote IRQ
 shared-memory demo run without an RTOS on the AMD RPU.

--- a/examples/linux/dts/xilinx/README.md
+++ b/examples/linux/dts/xilinx/README.md
@@ -1,5 +1,5 @@
 
-#### Building DTBs
+# Building DTBs
   - You will need a copy of the Linux source tree
   - For consitency use the same kernel version as the OpenAMP-CI Builds is using
   - Below we assume the kernel source is at ~/my-dir/kernel-source

--- a/examples/zephyr/README.md
+++ b/examples/zephyr/README.md
@@ -1,15 +1,6 @@
 # Zephyr Example Application
 
-This repository contains Zephyr example applications. The main purpose of this
-repository is to provide references and demo on the use of OpenAMP on Zephyr based applications. features demonstrated in this example are:
-
-- [rpmsg multi service][rms_app] application
-- [dual qemu ivshmem][dqi_app] application
-
-
-
-[rms_app]: #rpmsg_multi_services/README.md
-[dqi_app]: #dual_qemu_ivshmem/README.md
+Building of the Zephyr example applications is detailed below.
 
 ## Getting Started
 

--- a/examples/zephyr/dual_qemu_ivshmem/README.rst
+++ b/examples/zephyr/dual_qemu_ivshmem/README.rst
@@ -20,7 +20,7 @@ Note:
 *****
 
 * The Vendor-ID 0x1AF4 is being used from all other Zephyr in-tree samples, currently there
-is no Vendor allocated with the selected number.
+  is no Vendor allocated with the selected number.
 
 ivshmem-server needs to be available and running. The server is available in
 Zephyr SDK or pre-built in some distributions. Otherwise, it is available in

--- a/examples/zephyr/rpmsg_multi_services/README.rst
+++ b/examples/zephyr/rpmsg_multi_services/README.rst
@@ -1,8 +1,5 @@
 .. _openAMP_rsc_table_sample:
 
-OpenAMP multi services sample Application using resource table
-##############################################################
-
 Overview
 ********
 
@@ -28,8 +25,12 @@ Tested on board:
 * `imx8mp_evk/mimx8ml8/adsp        <https://docs.zephyrproject.org/latest/boards/nxp/imx8mp_evk/doc/index.html>`_
 * `imx95_evk/mimx9596/m7        <https://docs.zephyrproject.org/latest/boards/nxp/imx95_evk/doc/index.html>`_
 
+
 Building the application
 *************************
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_
 
 Zephyr
 ======

--- a/examples/zephyr/rpmsg_multi_services/README.rst
+++ b/examples/zephyr/rpmsg_multi_services/README.rst
@@ -187,8 +187,8 @@ in the remoteproc trace buffer depending on the Hardware.
 Demo 1: rpmsg-client-sample device
 ==================================
 
-Principle
------------
+Demo 1 Principle
+----------------
 
   This demo is automatically run when the co-processor firmware is started. It confirms that the rpmsg
   and virtio protocols are working properly. The Zephyr requests the creation of the
@@ -220,13 +220,13 @@ Associated traces
 Demo 2: rpmsg-tty device
 ========================
 
-Principle
----------
+Demo 2 Principle
+----------------
 
   This channel allows to create a /dev/ttyRPMSGx for terminal based communication with Zephyr.
 
-Demo
-----
+Demo 2 Instructions
+-------------------
 
 1. Check presence of the /dev/ttyRPMSG0
 
@@ -273,8 +273,8 @@ Demo
 Demo 3: dynamic creation/release of a rpmsg-tty device
 ======================================================
 
-Principle
----------
+Demo 3 Principle
+----------------
 
   This demo is based on the rpmsg_ctrl IOCtrls:
 
@@ -283,8 +283,8 @@ Principle
 * RPMSG_RELEASE_DEV_IOCTL: release the local rpmsg device and to send a name service destroy
   announcement to the remote processor
 
-Demo
-----
+Demo 3 Instructions
+-------------------
 
 1. Prerequisite
 
@@ -428,13 +428,13 @@ Demo
 Demo 4: rpmsg-char device
 =========================
 
-Principle
----------
+Demo 4 Principle
+----------------
 
   This channel allows to create a /dev/rpmsgX for character device based communication with Zephyr.
 
-Demo
-----
+Demo 4 Instructions
+-------------------
 
 1. Prerequisite
 
@@ -484,8 +484,8 @@ Demo
 Demo 5: Multi endpoints demo using rpmsg-ctrl device
 ====================================================
 
-Principle
----------
+Demo 5 Principle
+----------------
 
   Use the rpmsg_ctrl RPMSG_CREATE_EPT_IOCTL IoCtrl to instantiate endpoints on Linux side. Theses
   endpoints will not be associated to a channel but will communicate with a predefined remote proc
@@ -493,8 +493,8 @@ Principle
   endpoint with a prefixed address 0x1 has been created. When it receives a message it re-sends a the
   message to the Linux sender endpoint, prefixed by "from ept 0x0001:"
 
-Demo
-----
+Demo 5 Instructions
+-------------------
 
 1. Prerequisite
 

--- a/examples/zephyr/rpmsg_multi_services/README.rst
+++ b/examples/zephyr/rpmsg_multi_services/README.rst
@@ -89,7 +89,7 @@ Open a Linux shell (minicom, ssh, etc.)
 
 .. code-block:: console
 
-   root@linuxshell: insmod rpmsg_client_sample.ko rpmsg_tty.ko rpmsg_char.ko rpmsg_ctrl.ko
+   insmod rpmsg_client_sample.ko rpmsg_tty.ko rpmsg_char.ko rpmsg_ctrl.ko
 
 * Start the demo environment
 
@@ -98,8 +98,8 @@ Then start the firmware:
 
 .. code-block:: console
 
-  root@linuxshell: echo rpmsg_multi_services.elf > /sys/class/remoteproc/remoteproc0/firmware
-  root@linuxshell: echo start >/sys/class/remoteproc/remoteproc0/state
+  echo rpmsg_multi_services.elf > /sys/class/remoteproc/remoteproc0/firmware
+  echo start >/sys/class/remoteproc/remoteproc0/state
 
 Result on Zephyr console on boot
 ================================
@@ -107,6 +107,7 @@ Result on Zephyr console on boot
 The following messages will appear on the corresponding Zephyr console
 
 .. code-block:: console
+     :caption: Output
 
   [   54.495343] virtio_rpmsg_bus virtio0: rpmsg host is online
   [   54.500044] virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
@@ -126,7 +127,11 @@ This inform that following rpmsg channels devices have been created:
 
   .. code-block:: console
 
-    root@linuxshell: dmesg
+    dmesg
+
+  .. code-block:: console
+     :caption: Output
+
     ...
     [   54.500044] virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
     ...
@@ -135,7 +140,11 @@ This inform that following rpmsg channels devices have been created:
 
   .. code-block:: console
 
-    root@linuxshell: ls /dev/ttyRPMSG*
+    ls /dev/ttyRPMSG*
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/ttyRPMSG0
 
 
@@ -143,7 +152,11 @@ This inform that following rpmsg channels devices have been created:
 
   .. code-block:: console
 
-    root@linuxshell: ls /dev/rpmsg?
+    ls /dev/rpmsg?
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/rpmsg0
 
 The following messages will appear on the corresponding Zephyr console or
@@ -151,7 +164,11 @@ in the remoteproc trace buffer depending on the Hardware.
 
 .. code-block:: console
 
-  root@linuxshell:  cat /sys/kernel/debug/remoteproc/remoteproc0/trace0
+  cat /sys/kernel/debug/remoteproc/remoteproc0/trace0
+
+.. code-block:: console
+     :caption: Output
+
   *** Booting Zephyr OS build zephyr-v3.2.0-1-g6b49008b6b83  ***
   Starting application threads!
 
@@ -185,6 +202,7 @@ Associated traces
 -----------------
 
   .. code-block:: console
+     :caption: Output
 
     [   54.548954] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: new channel: 0x402 -> 0x400!
     [   54.557337] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 1 (src: 0x400)
@@ -215,9 +233,17 @@ Demo
   By default the Zephyr has created a rpmsg-tty channel
 
   .. code-block:: console
+     :caption: Output
 
     [   54.507923] virtio_rpmsg_bus virtio0: creating channel rpmsg-tty addr 0x401
-    root@linuxshell: ls /dev/ttyRPMSG*
+
+  .. code-block:: console
+
+    ls /dev/ttyRPMSG*
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/ttyRPMSG0
 
 2. Send and receive messages on /dev/ttyRPMSG0
@@ -227,10 +253,21 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: cat /dev/ttyRPMSG0 &
-    root@linuxshell: echo "Hello Zephyr" >/dev/ttyRPMSG0
+    cat /dev/ttyRPMSG0 &
+    echo "Hello Zephyr" >/dev/ttyRPMSG0
+
+  .. code-block:: console
+     :caption: Output
+
     TTY 0: Hello Zephyr
-    root@linuxshell: echo "Goodbye Zephyr" >/dev/ttyRPMSG0
+
+  .. code-block:: console
+
+    echo "Goodbye Zephyr" >/dev/ttyRPMSG0
+
+  .. code-block:: console
+     :caption: Output
+
     TTY 0: Goodbye Zephyr
 
 Demo 3: dynamic creation/release of a rpmsg-tty device
@@ -258,15 +295,19 @@ Demo
 
     .. code-block:: console
 
-      root@linuxshell: cat /dev/ttyRPMSG0 &
-      root@linuxshell: echo "Hello Zephyr" >/dev/ttyRPMSG0
+      cat /dev/ttyRPMSG0 &
+      echo "Hello Zephyr" >/dev/ttyRPMSG0
+
+  .. code-block:: console
+     :caption: Output
+
       TTY 0: Hello Zephyr
 
   * Check if the rpmsg-utils tools are installed on your platform.
 
     .. code-block:: console
 
-      root@linuxshell: rpmsg_ping
+      rpmsg_ping
 
 
   * If the rpmsg_ping application does not exist:
@@ -280,7 +321,7 @@ Demo
 
     .. code-block:: console
 
-      root@linuxshell: echo -n 'file virtio_rpmsg_bus.c +p' > /sys/kernel/debug/dynamic_debug/control
+      echo -n 'file virtio_rpmsg_bus.c +p' > /sys/kernel/debug/dynamic_debug/control
 
 2. create a new TTY channel
 
@@ -296,13 +337,17 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_export_dev /dev/rpmsg_ctrl0 rpmsg-tty 257 -1
+    ./rpmsg_export_dev /dev/rpmsg_ctrl0 rpmsg-tty 257 -1
 
   The /dev/ttyRPMSG1 is created
 
   .. code-block:: console
 
-    root@linuxshell: ls /dev/ttyRPMSG*
+    ls /dev/ttyRPMSG*
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/ttyRPMSG0  /dev/ttyRPMSG1
 
   A name service announcement has been sent to Zephyr, which has created a local endpoint (@ 0x400),
@@ -310,7 +355,11 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: dmesg
+    dmesg
+
+  .. code-block:: console
+     :caption: Output
+
     [  115.757439] rpmsg_tty virtio0.rpmsg-tty.257.-1: TX From 0x101, To 0x35, Len 40, Flags 0, Reserved 0
     [  115.757497] rpmsg_virtio TX: 01 01 00 00 35 00 00 00 00 00 00 00 28 00 00 00  ....5.......(...
     [  115.757514] rpmsg_virtio TX: 72 70 6d 73 67 2d 74 74 79 00 00 00 00 00 00 00  rpmsg-tty.......
@@ -330,11 +379,22 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: cat /dev/ttyRPMSG0 &
-    root@linuxshell: cat /dev/ttyRPMSG1 &
-    root@linuxshell: echo hello dev0 >/dev/ttyRPMSG0
+    cat /dev/ttyRPMSG0 &
+    cat /dev/ttyRPMSG1 &
+    echo hello dev0 >/dev/ttyRPMSG0
+
+  .. code-block:: console
+     :caption: Output
+
     TTY 0: hello dev0
-    root@linuxshell: echo hello dev1 >/dev/ttyRPMSG1
+
+  .. code-block:: console
+
+    echo hello dev1 >/dev/ttyRPMSG1
+
+  .. code-block:: console
+     :caption: Output
+
     TTY 1: hello dev1
 
 4. Destroy RPMSG TTY devices
@@ -343,21 +403,25 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 257 -1
+    ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 257 -1
 
   Destroy the /dev/ttyRPMSG0
   * Get the source address
 
   .. code-block:: console
 
-    root@linuxshell: cat /sys/bus/rpmsg/devices/virtio0.rpmsg-tty.-1.*/src
+    cat /sys/bus/rpmsg/devices/virtio0.rpmsg-tty.-1.*/src
+
+  .. code-block:: console
+     :caption: Output
+
     0x402
 
   * Destroy the /dev/ttyRPMSG0 specifying the address 1026 (0x402)
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 1026 -1
+    ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 1026 -1
 
   The /dev/ttyRPMGx devices no more exists
 
@@ -388,6 +452,7 @@ Demo
   By default the Zephyr has created a rpmsg-raw channel
 
   .. code-block:: console
+     :caption: Output
 
     [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
 
@@ -395,7 +460,11 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: ls /dev/rpmsg?
+    ls /dev/rpmsg?
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/rpmsg0
 
 4. Send and receive messages on /dev/rpmsg0
@@ -405,7 +474,11 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_ping /dev/rpmsg0
+    ./rpmsg_ping /dev/rpmsg0
+
+  .. code-block:: console
+     :caption: Output
+
     message for /dev/rpmsg0: "from ept 0x0402: ping /dev/rpmsg0"
 
 Demo 5: Multi endpoints demo using rpmsg-ctrl device
@@ -439,6 +512,7 @@ Demo
   By default the Zephyr has created a rpmsg-raw channel
 
   .. code-block:: console
+     :caption: Output
 
     [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
 
@@ -446,38 +520,75 @@ Demo
 
   .. code-block:: console
 
-    root@linuxshell: ls /dev/rpmsg*
+    ls /dev/rpmsg*
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/rpmsg0       /dev/rpmsg_ctrl0
 
 4. Create 3 new endpoints
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint1 100 1
-    root@linuxshell: ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 101 1
-    root@linuxshell: ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 103 1
-    root@linuxshell: ls /dev/rpmsg?
+    ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint1 100 1
+    ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 101 1
+    ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 103 1
+    ls /dev/rpmsg?
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/rpmsg0  /dev/rpmsg1  /dev/rpmsg2  /dev/rpmsg3
 
 5. Test them
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_ping  /dev/rpmsg0
+    ./rpmsg_ping  /dev/rpmsg0
+
+  .. code-block:: console
+     :caption: Output
+
     message for /dev/rpmsg0: "from ept 0x0402: ping /dev/rpmsg0"
-    root@linuxshell: ./rpmsg_ping  /dev/rpmsg1
+
+  .. code-block:: console
+
+    ./rpmsg_ping  /dev/rpmsg1
+
+  .. code-block:: console
+     :caption: Output
+
     message for /dev/rpmsg1: "from ept 0x0001: ping /dev/rpmsg1"
-    root@linuxshell: ./rpmsg_ping  /dev/rpmsg2
+
+  .. code-block:: console
+
+    ./rpmsg_ping  /dev/rpmsg2
+
+  .. code-block:: console
+     :caption: Output
+
     message for /dev/rpmsg2: "from ept 0x0001: ping /dev/rpmsg2"
-    root@linuxshell: ./rpmsg_ping  /dev/rpmsg3
+
+  .. code-block:: console
+
+    ./rpmsg_ping  /dev/rpmsg3
+
+  .. code-block:: console
+     :caption: Output
+
     message for /dev/rpmsg3: "from ept 0x0001: ping /dev/rpmsg3"
 
 6. Destroy them
 
   .. code-block:: console
 
-    root@linuxshell: ./rpmsg_destroy_ept /dev/rpmsg1
-    root@linuxshell: ./rpmsg_destroy_ept /dev/rpmsg2
-    root@linuxshell: ./rpmsg_destroy_ept /dev/rpmsg3
-    root@linuxshell: ls /dev/rpmsg?
+    ./rpmsg_destroy_ept /dev/rpmsg1
+    ./rpmsg_destroy_ept /dev/rpmsg2
+    ./rpmsg_destroy_ept /dev/rpmsg3
+    ls /dev/rpmsg?
+
+  .. code-block:: console
+     :caption: Output
+
     /dev/rpmsg0

--- a/examples/zephyr/rpmsg_multi_services/README.rst
+++ b/examples/zephyr/rpmsg_multi_services/README.rst
@@ -107,19 +107,19 @@ Result on Zephyr console on boot
 The following messages will appear on the corresponding Zephyr console
 
 .. code-block:: console
-     :caption: Output
+   :caption: Output
 
-  [   54.495343] virtio_rpmsg_bus virtio0: rpmsg host is online
-  [   54.500044] virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
-  [   54.507923] virtio_rpmsg_bus virtio0: creating channel rpmsg-tty addr 0x401
-  [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
-  [   54.548954] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: new channel: 0x402 -> 0x400!
-  [   54.557337] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 1 (src: 0x400)
-  [   54.565532] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 2 (src: 0x400)
-  [   54.581090] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 3 (src: 0x400)
-  [   54.588699] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 4 (src: 0x400)
-  [   54.599424] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 5 (src: 0x400)
-  ...
+   [   54.495343] virtio_rpmsg_bus virtio0: rpmsg host is online
+   [   54.500044] virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
+   [   54.507923] virtio_rpmsg_bus virtio0: creating channel rpmsg-tty addr 0x401
+   [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
+   [   54.548954] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: new channel: 0x402 -> 0x400!
+   [   54.557337] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 1 (src: 0x400)
+   [   54.565532] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 2 (src: 0x400)
+   [   54.581090] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 3 (src: 0x400)
+   [   54.588699] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 4 (src: 0x400)
+   [   54.599424] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 5 (src: 0x400)
+   ...
 
 This inform that following rpmsg channels devices have been created:
 
@@ -127,25 +127,25 @@ This inform that following rpmsg channels devices have been created:
 
   .. code-block:: console
 
-    dmesg
+     dmesg
 
   .. code-block:: console
      :caption: Output
 
-    ...
-    [   54.500044] virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
-    ...
+     ...
+     [   54.500044] virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
+     ...
 
 * a rpmsg-tty device
 
   .. code-block:: console
 
-    ls /dev/ttyRPMSG*
+     ls /dev/ttyRPMSG*
 
   .. code-block:: console
      :caption: Output
 
-    /dev/ttyRPMSG0
+     /dev/ttyRPMSG0
 
 
 * a rpmsg-raw device
@@ -157,31 +157,31 @@ This inform that following rpmsg channels devices have been created:
   .. code-block:: console
      :caption: Output
 
-    /dev/rpmsg0
+     /dev/rpmsg0
 
 The following messages will appear on the corresponding Zephyr console or
 in the remoteproc trace buffer depending on the Hardware.
 
 .. code-block:: console
 
-  cat /sys/kernel/debug/remoteproc/remoteproc0/trace0
+   cat /sys/kernel/debug/remoteproc/remoteproc0/trace0
 
 .. code-block:: console
-     :caption: Output
+   :caption: Output
 
-  *** Booting Zephyr OS build zephyr-v3.2.0-1-g6b49008b6b83  ***
-  Starting application threads!
+   *** Booting Zephyr OS build zephyr-v3.2.0-1-g6b49008b6b83  ***
+   Starting application threads!
 
-  OpenAMP[remote]  linux responder demo started
+   OpenAMP[remote]  linux responder demo started
 
-  OpenAMP[remote] Linux sample client responder started
+   OpenAMP[remote] Linux sample client responder started
 
-  OpenAMP[remote] Linux tty responder started
+   OpenAMP[remote] Linux tty responder started
 
-  OpenAMP[remote] Linux raw data responder started
+   OpenAMP[remote] Linux raw data responder started
 
-  OpenAMP[remote] create a endpoint with address and dest_address set to 0x1
-  OpenAMP Linux sample client responder ended
+   OpenAMP[remote] create a endpoint with address and dest_address set to 0x1
+   OpenAMP Linux sample client responder ended
 
 
 Demo 1: rpmsg-client-sample device
@@ -204,17 +204,17 @@ Associated traces
   .. code-block:: console
      :caption: Output
 
-    [   54.548954] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: new channel: 0x402 -> 0x400!
-    [   54.557337] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 1 (src: 0x400)
-    [   54.565532] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 2 (src: 0x400)
+     [   54.548954] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: new channel: 0x402 -> 0x400!
+     [   54.557337] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 1 (src: 0x400)
+     [   54.565532] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 2 (src: 0x400)
 
-      ...
+       ...
 
-    [   55.436401] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 99 (src: 0x400)
-    [   55.445343] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 100 (src: 0x400)
-    [   55.454280] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: goodbye!
-    [   55.461424] virtio_rpmsg_bus virtio0: destroying channel rpmsg-client-sample addr 0x400
-    [   55.469707] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: rpmsg sample client driver is removed
+     [   55.436401] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 99 (src: 0x400)
+     [   55.445343] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 100 (src: 0x400)
+     [   55.454280] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: goodbye!
+     [   55.461424] virtio_rpmsg_bus virtio0: destroying channel rpmsg-client-sample addr 0x400
+     [   55.469707] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: rpmsg sample client driver is removed
 
 
 Demo 2: rpmsg-tty device
@@ -235,16 +235,16 @@ Demo
   .. code-block:: console
      :caption: Output
 
-    [   54.507923] virtio_rpmsg_bus virtio0: creating channel rpmsg-tty addr 0x401
+     [   54.507923] virtio_rpmsg_bus virtio0: creating channel rpmsg-tty addr 0x401
 
   .. code-block:: console
 
-    ls /dev/ttyRPMSG*
+     ls /dev/ttyRPMSG*
 
   .. code-block:: console
      :caption: Output
 
-    /dev/ttyRPMSG0
+     /dev/ttyRPMSG0
 
 2. Send and receive messages on /dev/ttyRPMSG0
 
@@ -253,22 +253,22 @@ Demo
 
   .. code-block:: console
 
-    cat /dev/ttyRPMSG0 &
-    echo "Hello Zephyr" >/dev/ttyRPMSG0
+     cat /dev/ttyRPMSG0 &
+     echo "Hello Zephyr" >/dev/ttyRPMSG0
 
   .. code-block:: console
      :caption: Output
 
-    TTY 0: Hello Zephyr
+     TTY 0: Hello Zephyr
 
   .. code-block:: console
 
-    echo "Goodbye Zephyr" >/dev/ttyRPMSG0
+     echo "Goodbye Zephyr" >/dev/ttyRPMSG0
 
   .. code-block:: console
      :caption: Output
 
-    TTY 0: Goodbye Zephyr
+     TTY 0: Goodbye Zephyr
 
 Demo 3: dynamic creation/release of a rpmsg-tty device
 ======================================================
@@ -337,65 +337,65 @@ Demo
 
   .. code-block:: console
 
-    ./rpmsg_export_dev /dev/rpmsg_ctrl0 rpmsg-tty 257 -1
+     ./rpmsg_export_dev /dev/rpmsg_ctrl0 rpmsg-tty 257 -1
 
   The /dev/ttyRPMSG1 is created
 
   .. code-block:: console
 
-    ls /dev/ttyRPMSG*
+     ls /dev/ttyRPMSG*
 
   .. code-block:: console
      :caption: Output
 
-    /dev/ttyRPMSG0  /dev/ttyRPMSG1
+     /dev/ttyRPMSG0  /dev/ttyRPMSG1
 
   A name service announcement has been sent to Zephyr, which has created a local endpoint (@ 0x400),
   and sent a "bound" message to the /dev/ttyRPMG1 (@ 257)
 
   .. code-block:: console
 
-    dmesg
+     dmesg
 
   .. code-block:: console
      :caption: Output
 
-    [  115.757439] rpmsg_tty virtio0.rpmsg-tty.257.-1: TX From 0x101, To 0x35, Len 40, Flags 0, Reserved 0
-    [  115.757497] rpmsg_virtio TX: 01 01 00 00 35 00 00 00 00 00 00 00 28 00 00 00  ....5.......(...
-    [  115.757514] rpmsg_virtio TX: 72 70 6d 73 67 2d 74 74 79 00 00 00 00 00 00 00  rpmsg-tty.......
-    [  115.757528] rpmsg_virtio TX: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
-    [  115.757540] rpmsg_virtio TX: 01 01 00 00 00 00 00 00                          ........
-    [  115.757568] remoteproc remoteproc0: kicking vq index: 1
-    [  115.757590] stm32-ipcc 4c001000.mailbox: stm32_ipcc_send_data: chan:1
-    [  115.757850] stm32-ipcc 4c001000.mailbox: stm32_ipcc_tx_irq: chan:1 tx
-    [  115.757906] stm32-ipcc 4c001000.mailbox: stm32_ipcc_rx_irq: chan:0 rx
-    [  115.757969] remoteproc remoteproc0: vq index 0 is interrupted
-    [  115.757994] virtio_rpmsg_bus virtio0: From: 0x400, To: 0x101, Len: 6, Flags: 0, Reserved: 0
-    [  115.758022] rpmsg_virtio RX: 00 04 00 00 01 01 00 00 00 00 00 00 06 00 00 00  ................
-    [  115.758035] rpmsg_virtio RX: 62 6f 75 6e 64 00                                bound.
-    [  115.758077] virtio_rpmsg_bus virtio0: Received 1 messages
+     [  115.757439] rpmsg_tty virtio0.rpmsg-tty.257.-1: TX From 0x101, To 0x35, Len 40, Flags 0, Reserved 0
+     [  115.757497] rpmsg_virtio TX: 01 01 00 00 35 00 00 00 00 00 00 00 28 00 00 00  ....5.......(...
+     [  115.757514] rpmsg_virtio TX: 72 70 6d 73 67 2d 74 74 79 00 00 00 00 00 00 00  rpmsg-tty.......
+     [  115.757528] rpmsg_virtio TX: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+     [  115.757540] rpmsg_virtio TX: 01 01 00 00 00 00 00 00                          ........
+     [  115.757568] remoteproc remoteproc0: kicking vq index: 1
+     [  115.757590] stm32-ipcc 4c001000.mailbox: stm32_ipcc_send_data: chan:1
+     [  115.757850] stm32-ipcc 4c001000.mailbox: stm32_ipcc_tx_irq: chan:1 tx
+     [  115.757906] stm32-ipcc 4c001000.mailbox: stm32_ipcc_rx_irq: chan:0 rx
+     [  115.757969] remoteproc remoteproc0: vq index 0 is interrupted
+     [  115.757994] virtio_rpmsg_bus virtio0: From: 0x400, To: 0x101, Len: 6, Flags: 0, Reserved: 0
+     [  115.758022] rpmsg_virtio RX: 00 04 00 00 01 01 00 00 00 00 00 00 06 00 00 00  ................
+     [  115.758035] rpmsg_virtio RX: 62 6f 75 6e 64 00                                bound.
+     [  115.758077] virtio_rpmsg_bus virtio0: Received 1 messages
 
 3. Play with /dev/ttyRPMSG0 and /dev/ttyRPMSG1
 
   .. code-block:: console
 
-    cat /dev/ttyRPMSG0 &
-    cat /dev/ttyRPMSG1 &
-    echo hello dev0 >/dev/ttyRPMSG0
+     cat /dev/ttyRPMSG0 &
+     cat /dev/ttyRPMSG1 &
+     echo hello dev0 >/dev/ttyRPMSG0
 
   .. code-block:: console
      :caption: Output
 
-    TTY 0: hello dev0
+     TTY 0: hello dev0
 
   .. code-block:: console
 
-    echo hello dev1 >/dev/ttyRPMSG1
+     echo hello dev1 >/dev/ttyRPMSG1
 
   .. code-block:: console
      :caption: Output
 
-    TTY 1: hello dev1
+     TTY 1: hello dev1
 
 4. Destroy RPMSG TTY devices
 
@@ -403,25 +403,25 @@ Demo
 
   .. code-block:: console
 
-    ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 257 -1
+     ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 257 -1
 
   Destroy the /dev/ttyRPMSG0
   * Get the source address
 
   .. code-block:: console
 
-    cat /sys/bus/rpmsg/devices/virtio0.rpmsg-tty.-1.*/src
+     cat /sys/bus/rpmsg/devices/virtio0.rpmsg-tty.-1.*/src
 
   .. code-block:: console
      :caption: Output
 
-    0x402
+     0x402
 
   * Destroy the /dev/ttyRPMSG0 specifying the address 1026 (0x402)
 
   .. code-block:: console
 
-    ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 1026 -1
+     ./rpmsg_export_dev /dev/rpmsg_ctrl0 -d rpmsg-tty 1026 -1
 
   The /dev/ttyRPMGx devices no more exists
 
@@ -454,18 +454,18 @@ Demo
   .. code-block:: console
      :caption: Output
 
-    [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
+     [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
 
 3. Check device exists
 
   .. code-block:: console
 
-    ls /dev/rpmsg?
+     ls /dev/rpmsg?
 
   .. code-block:: console
      :caption: Output
 
-    /dev/rpmsg0
+     /dev/rpmsg0
 
 4. Send and receive messages on /dev/rpmsg0
 
@@ -474,12 +474,12 @@ Demo
 
   .. code-block:: console
 
-    ./rpmsg_ping /dev/rpmsg0
+     ./rpmsg_ping /dev/rpmsg0
 
   .. code-block:: console
      :caption: Output
 
-    message for /dev/rpmsg0: "from ept 0x0402: ping /dev/rpmsg0"
+     message for /dev/rpmsg0: "from ept 0x0402: ping /dev/rpmsg0"
 
 Demo 5: Multi endpoints demo using rpmsg-ctrl device
 ====================================================
@@ -514,32 +514,32 @@ Demo
   .. code-block:: console
      :caption: Output
 
-    [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
+     [   54.514795] virtio_rpmsg_bus virtio0: creating channel rpmsg-raw addr 0x402
 
 3. Check device exists
 
   .. code-block:: console
 
-    ls /dev/rpmsg*
+     ls /dev/rpmsg*
 
   .. code-block:: console
      :caption: Output
 
-    /dev/rpmsg0       /dev/rpmsg_ctrl0
+     /dev/rpmsg0       /dev/rpmsg_ctrl0
 
 4. Create 3 new endpoints
 
   .. code-block:: console
 
-    ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint1 100 1
-    ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 101 1
-    ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 103 1
-    ls /dev/rpmsg?
+     ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint1 100 1
+     ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 101 1
+     ./rpmsg_export_ept /dev/rpmsg_ctrl0 my_endpoint2 103 1
+     ls /dev/rpmsg?
 
   .. code-block:: console
      :caption: Output
 
-    /dev/rpmsg0  /dev/rpmsg1  /dev/rpmsg2  /dev/rpmsg3
+     /dev/rpmsg0  /dev/rpmsg1  /dev/rpmsg2  /dev/rpmsg3
 
 5. Test them
 
@@ -550,45 +550,45 @@ Demo
   .. code-block:: console
      :caption: Output
 
-    message for /dev/rpmsg0: "from ept 0x0402: ping /dev/rpmsg0"
+     message for /dev/rpmsg0: "from ept 0x0402: ping /dev/rpmsg0"
 
   .. code-block:: console
 
-    ./rpmsg_ping  /dev/rpmsg1
-
-  .. code-block:: console
-     :caption: Output
-
-    message for /dev/rpmsg1: "from ept 0x0001: ping /dev/rpmsg1"
-
-  .. code-block:: console
-
-    ./rpmsg_ping  /dev/rpmsg2
+     ./rpmsg_ping  /dev/rpmsg1
 
   .. code-block:: console
      :caption: Output
 
-    message for /dev/rpmsg2: "from ept 0x0001: ping /dev/rpmsg2"
+     message for /dev/rpmsg1: "from ept 0x0001: ping /dev/rpmsg1"
 
   .. code-block:: console
 
-    ./rpmsg_ping  /dev/rpmsg3
+     ./rpmsg_ping  /dev/rpmsg2
 
   .. code-block:: console
      :caption: Output
 
-    message for /dev/rpmsg3: "from ept 0x0001: ping /dev/rpmsg3"
+     message for /dev/rpmsg2: "from ept 0x0001: ping /dev/rpmsg2"
+
+  .. code-block:: console
+
+     ./rpmsg_ping  /dev/rpmsg3
+
+  .. code-block:: console
+     :caption: Output
+
+     message for /dev/rpmsg3: "from ept 0x0001: ping /dev/rpmsg3"
 
 6. Destroy them
 
   .. code-block:: console
 
-    ./rpmsg_destroy_ept /dev/rpmsg1
-    ./rpmsg_destroy_ept /dev/rpmsg2
-    ./rpmsg_destroy_ept /dev/rpmsg3
-    ls /dev/rpmsg?
+     ./rpmsg_destroy_ept /dev/rpmsg1
+     ./rpmsg_destroy_ept /dev/rpmsg2
+     ./rpmsg_destroy_ept /dev/rpmsg3
+     ls /dev/rpmsg?
 
   .. code-block:: console
      :caption: Output
 
-    /dev/rpmsg0
+     /dev/rpmsg0


### PR DESCRIPTION
This pull request (PR) supports openamp-docs PR https://github.com/OpenAMP/openamp-docs/pull/82, whose intent is to integrate git submodule documentation into openamp readthedocs.
Any markdown (*.md) or restructured text (*.rst) not included in openamp-docs show up as sphinx documentation warnings "toc not included", so these are either introduced into readthedocs or hidden if not relevant.