### PR TITLE
rpmsg buf size config via vdev config space.

### DIFF
--- a/examples/legacy_apps/examples/echo/rpmsg-echo.c
+++ b/examples/legacy_apps/examples/echo/rpmsg-echo.c
@@ -79,8 +79,8 @@ int rpmsg_echo_app(struct rpmsg_device *rdev, void *priv)
 		  "created rpmsg channel %s, src=0x%x, dst=0x%x\r\n",
 		   RPMSG_SERVICE_NAME, lept.addr, lept.dest_addr);
 
-	metal_dbg("RPMsg device TX buffer size: %#x\r\n", rpmsg_get_tx_buffer_size(&lept));
-	metal_dbg("RPMsg device RX buffer size: %#x\r\n", rpmsg_get_rx_buffer_size(&lept));
+	metal_info("RPMsg device TX buffer size: %d\r\n", rpmsg_get_tx_buffer_size(&lept));
+	metal_info("RPMsg device RX buffer size: %d\r\n", rpmsg_get_rx_buffer_size(&lept));
 
 	while(1) {
 		platform_poll(priv);

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
@@ -362,6 +362,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 			   void (*rst_cb)(struct virtio_device *vdev),
 			   rpmsg_ns_bind_cb ns_bind_cb)
 {
+	struct remote_resource_table *rsc_tbl;
 	struct remoteproc *rproc = platform;
 	struct rpmsg_virtio_device *rpmsg_vdev;
 	struct virtio_device *vdev;
@@ -370,6 +371,8 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 	int ret;
 
 	restore_initial_rsc_table();
+
+	rsc_tbl = rproc->rsc_table;
 
 	rpmsg_vdev = metal_allocate_memory(sizeof(*rpmsg_vdev));
 	if (!rpmsg_vdev)
@@ -394,9 +397,9 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 
 	metal_dbg("initializing rpmsg vdev\r\n");
 	/* RPMsg virtio device can set shared buffers pool argument to NULL */
-	ret =  rpmsg_init_vdev(rpmsg_vdev, vdev, ns_bind_cb,
-			       shbuf_io,
-			       &shpool);
+	ret =  rpmsg_init_vdev_with_config(rpmsg_vdev, vdev, ns_bind_cb,
+					   shbuf_io, &shpool,
+					   &rsc_tbl->vdev_config);
 	if (ret) {
 		metal_err("failed rpmsg_init_vdev\r\n");
 		goto err2;

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
@@ -408,6 +408,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 			   void (*rst_cb)(struct virtio_device *vdev),
 			   rpmsg_ns_bind_cb ns_bind_cb)
 {
+	struct remote_resource_table *rsc_tbl;
 	struct remoteproc *rproc = platform;
 	struct rpmsg_virtio_device *rpmsg_vdev;
 	struct virtio_device *vdev;
@@ -416,6 +417,8 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 	int ret;
 
 	restore_initial_rsc_table();
+
+	rsc_tbl = rproc->rsc_table;
 
 	rpmsg_vdev = metal_allocate_memory(sizeof(*rpmsg_vdev));
 	if (!rpmsg_vdev)
@@ -440,9 +443,9 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 
 	metal_dbg("initializing rpmsg vdev\r\n");
 	/* RPMsg virtio device can set shared buffers pool argument to NULL */
-	ret =  rpmsg_init_vdev(rpmsg_vdev, vdev, ns_bind_cb,
-			       shbuf_io,
-			       &shpool);
+	ret =  rpmsg_init_vdev_with_config(rpmsg_vdev, vdev, ns_bind_cb,
+					   shbuf_io, &shpool,
+					   &rsc_tbl->vdev_config);
 	if (ret) {
 		metal_err("failed rpmsg_init_vdev\r\n");
 		goto err2;

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c
@@ -56,14 +56,23 @@ struct remote_resource_table __resource resources = {
 	 },
 
 	/* Virtio device entry */
-	{
-	 RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0, 0, 0,
-	 NUM_VRINGS, {0, 0},
-	 },
+	.rpmsg_vdev = {
+		RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0,
+		/* vdev config space len */
+		sizeof(struct rpmsg_virtio_config), 0,
+		NUM_VRINGS, {0, 0},
+	},
 
 	/* Vring rsc entry - part of vdev rsc entry */
 	{RING_TX, VRING_ALIGN, VRING_SIZE, 1, 0},
 	{RING_RX, VRING_ALIGN, VRING_SIZE, 2, 0},
+	/* vdev config space */
+	.vdev_config = {
+		.version = 1,
+		.h2r_buf_size = 256, /* host to remote, i.e. tx for host */
+		.r2h_buf_size = 128, /* remote to host, i.e. rx for host */
+		.split_shpool = false
+	},
 };
 
 struct remote_resource_table_metadata __resource_metadata resources_metadata = {

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c
@@ -21,8 +21,9 @@
 
 #define RSC_TBL_XLNX_MAGIC	((uint32_t)'x' << 24 | (uint32_t)'a' << 16 | \
 				 (uint32_t)'m' << 8 | (uint32_t)'p')
- 
-#define RPMSG_VDEV_DFEATURES        (1 << VIRTIO_RPMSG_F_NS)
+
+#define RPMSG_VDEV_DFEATURES        (1 << VIRTIO_RPMSG_F_NS | \
+				     1 << VIRTIO_RPMSG_F_BUFSZ)
 
 /* VirtIO rpmsg device id */
 #define VIRTIO_ID_RPMSG_             7

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.c
@@ -28,17 +28,19 @@
 #define VIRTIO_ID_RPMSG_             7
 
 #define NUM_VRINGS                  0x02
-#define VRING_ALIGN                 0x1000
+#define VRING_ALIGN                 64
 #ifndef RING_TX
 #define RING_TX                     FW_RSC_U32_ADDR_ANY
 #endif /* !RING_TX */
 #ifndef RING_RX
 #define RING_RX                     FW_RSC_U32_ADDR_ANY
 #endif /* RING_RX */
-#define VRING_SIZE                  256
+#define VRING_SIZE                  64
 
 #define NUM_TABLE_ENTRIES           2
 #define RSC_TRACE_SZ		    4096
+
+#define RPMSG_BUF_ALIGN		    64
 
 static struct remote_resource_table *initial_resources;
 static char rsc_trace_buf[RSC_TRACE_SZ];
@@ -58,14 +60,25 @@ struct remote_resource_table __resource resources = {
 
 	/* Virtio device entry */
 	.rpmsg_vdev = {
-		RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0, 0, 0,
+		RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0,
+		/* vdev config space len */
+		sizeof(struct rpmsg_virtio_config), 0,
 		NUM_VRINGS, {0, 0},
 	},
 
 	/* Vring rsc entry - part of vdev rsc entry */
 	{RING_TX, VRING_ALIGN, VRING_SIZE, 1, 0},
 	{RING_RX, VRING_ALIGN, VRING_SIZE, 2, 0},
-
+	/* vdev config space */
+	.vdev_config = {
+		.version = 1,
+		.reserved = 0,
+		.size = (uint16_t)(sizeof(struct rpmsg_virtio_config) - sizeof(bool)),
+		.alignment = RPMSG_BUF_ALIGN,
+		.reserved1 = 0,
+		.h2r_buf_size = metal_align_up(4096, RPMSG_BUF_ALIGN), /* host to remote, i.e. tx for host */
+		.r2h_buf_size = metal_align_up(4096, RPMSG_BUF_ALIGN), /* remote to host, i.e. rx for host */
+	},
 	/* trace buffer for logs, accessible via debugfs */
 	.rsc_trace = {
 		.type =		RSC_TRACE,

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.h
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.h
@@ -34,6 +34,7 @@ struct remote_resource_table {
 	struct fw_rsc_vdev rpmsg_vdev;
 	struct fw_rsc_vdev_vring rpmsg_vring0;
 	struct fw_rsc_vdev_vring rpmsg_vring1;
+	struct rpmsg_virtio_config vdev_config;
 }__attribute__((packed, aligned(0x100)));
 
 struct remote_resource_table_metadata {

--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.h
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/rsc_table.h
@@ -34,6 +34,7 @@ struct remote_resource_table {
 	struct fw_rsc_vdev rpmsg_vdev;
 	struct fw_rsc_vdev_vring rpmsg_vring0;
 	struct fw_rsc_vdev_vring rpmsg_vring1;
+	struct rpmsg_virtio_config vdev_config;
 	struct fw_rsc_trace rsc_trace;
 }__attribute__((packed, aligned(0x100)));
 


### PR DESCRIPTION
Corresponding Linux kernel patch series; https://lore.kernel.org/all/20251114184640.3020427-1-tanmay.shah@amd.com/

open-amp library PR: https://github.com/OpenAMP/open-amp/pull/684 