### PR TITLE
legacy_apps: xlnx: fix build system for native cmake build

### DIFF
--- a/examples/legacy_apps/machine/xlnx/CMakeLists.txt
+++ b/examples/legacy_apps/machine/xlnx/CMakeLists.txt
@@ -23,6 +23,8 @@ include(CheckSymbolExists)
 #set_property (GLOBAL PROPERTY MACHINE ${MACHINE})
 #set (PROJECT_MACHINE ${MACHINE})
 
+set (_vitis_build ON)
+
 get_property (OPENAMP_APP_NAME GLOBAL PROPERTY OPENAMP_APP_NAME)
 if(OPENAMP_APP_NAME STREQUAL "rpc_demo")
   set(_app rpc_demo)
@@ -31,120 +33,126 @@ elseif(OPENAMP_APP_NAME STREQUAL "echo")
 elseif(OPENAMP_APP_NAME STREQUAL "matrix_multiply")
   set (_app matrix_multiplyd)
 else()
-  message(FATAL_ERROR "OPENAMP_APP_NAME not picked up")
-endif()
-message("OpenAMP: OPENAMP_APP_NAME: ${OPENAMP_APP_NAME}")
-
-# Ensure that for Compile step that the _AMD_GENERATED_ symbol is present
-# for app build if it was provided in CMake configure tooling
-if (_AMD_GENERATED_)
-  add_definitions(-D_AMD_GENERATED_)
+  add_subdirectory(${PROJECT_MACHINE})
+  set (_vitis_build OFF)
 endif()
 
-string(TOUPPER "${CMAKE_MACHINE}" _soc)
+if (_vitis_build)
 
-if(_soc STREQUAL "ZYNQMP" OR _soc STREQUAL "VERSAL")
-    set_property(GLOBAL PROPERTY SOC "${_soc}")
-else()
-    message(FATAL_ERROR "Unsupported CMAKE_MACHINE: ${CMAKE_MACHINE}")
-endif()
+  message("OpenAMP: OPENAMP_APP_NAME: ${OPENAMP_APP_NAME}")
 
-get_property (SOC GLOBAL PROPERTY SOC)
-message("OpenAMP: SOC in build is: ${SOC}")
+  # Ensure that for Compile step that the _AMD_GENERATED_ symbol is present
+  # for app build if it was provided in CMake configure tooling
+  if (_AMD_GENERATED_)
+    add_definitions(-D_AMD_GENERATED_)
+  endif()
 
-# Lopper plugin can generate linker meta data in below file
-# This can define RSC_TABLE so include before
-message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
-file (GLOB LINKER_METADATA_FILE "${CMAKE_SOURCE_DIR}/*Example.cmake")
-if (EXISTS ${LINKER_METADATA_FILE})
-  set_property(GLOBAL PROPERTY LINKER_METADATA_FILE ${LINKER_METADATA_FILE})
-  message("OpenAMP: Linker will be configured using file: ${LINKER_METADATA_FILE}")
-else()
-  message("OpenAMP: Linker will be configured using static linker script for ${SOC}")
-endif()
+  string(TOUPPER "${CMAKE_MACHINE}" _soc)
 
-get_property (OPENAMP_APP_NAME GLOBAL PROPERTY OPENAMP_APP_NAME)
-if (OPENAMP_APP_NAME STREQUAL "")
-  message(FATAL_ERROR "AMD-Xilinx: Demos: missing property OPENAMP_APP_NAME.")
-  return()
-#else()
-  #add_subdirectory (${APPS_ROOT_DIR}/machine ${CMAKE_CURRENT_BINARY_DIR}/machine_build)
-  #add_subdirectory (${APPS_ROOT_DIR}/system ${CMAKE_CURRENT_BINARY_DIR}/system_build)
-endif (OPENAMP_APP_NAME STREQUAL "")
+  if(_soc STREQUAL "ZYNQMP" OR _soc STREQUAL "VERSAL")
+      set_property(GLOBAL PROPERTY SOC "${_soc}")
+  else()
+      message(FATAL_ERROR "Unsupported CMAKE_MACHINE: ${CMAKE_MACHINE}")
+  endif()
 
-add_subdirectory(${PROJECT_MACHINE})
+  get_property (SOC GLOBAL PROPERTY SOC)
+  message("OpenAMP: SOC in build is: ${SOC}")
 
-# pull in original legacy app demo logic here
-set (_cflags "${CMAKE_C_FLAGS} ${APP_EXTRA_C_FLAGS} -fdata-sections -ffunction-sections")
-set (_fw_dir "${APPS_SHARE_DIR}")
+  # Lopper plugin can generate linker meta data in below file
+  # This can define RSC_TABLE so include before
+  message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+  file (GLOB LINKER_METADATA_FILE "${CMAKE_SOURCE_DIR}/*Example.cmake")
+  if (EXISTS ${LINKER_METADATA_FILE})
+    set_property(GLOBAL PROPERTY LINKER_METADATA_FILE ${LINKER_METADATA_FILE})
+    message("OpenAMP: Linker will be configured using file: ${LINKER_METADATA_FILE}")
+  else()
+    message("OpenAMP: Linker will be configured using static linker script for ${SOC}")
+  endif()
 
-collect(APP_INC_DIRS ${APPS_ROOT_DIR}/examples/${OPENAMP_APP_NAME})
-collect(APP_INC_DIRS ${APPS_ROOT_DIR}/machine/${MACHINE})
+  get_property (OPENAMP_APP_NAME GLOBAL PROPERTY OPENAMP_APP_NAME)
+  if (OPENAMP_APP_NAME STREQUAL "")
+    message(FATAL_ERROR "AMD-Xilinx: Demos: missing property OPENAMP_APP_NAME.")
+    return()
+  #else()
+    #add_subdirectory (${APPS_ROOT_DIR}/machine ${CMAKE_CURRENT_BINARY_DIR}/machine_build)
+    #add_subdirectory (${APPS_ROOT_DIR}/system ${CMAKE_CURRENT_BINARY_DIR}/system_build)
+  endif (OPENAMP_APP_NAME STREQUAL "")
 
-collector_list (_list PROJECT_INC_DIRS)
-collector_list (_app_list APP_INC_DIRS)
+  add_subdirectory(${PROJECT_MACHINE})
 
-include_directories (${_list} ${_app_list})
-include_directories (${APPS_ROOT_DIR}/examples/legacy_apps/include)
-link_directories (${_list} ${_app_list})
+  # pull in original legacy app demo logic here
+  set (_cflags "${CMAKE_C_FLAGS} ${APP_EXTRA_C_FLAGS} -fdata-sections -ffunction-sections")
+  set (_fw_dir "${APPS_SHARE_DIR}")
 
-get_property (_linker_opt GLOBAL PROPERTY APP_LINKER_OPT)
+  collect(APP_INC_DIRS ${APPS_ROOT_DIR}/examples/${OPENAMP_APP_NAME})
+  collect(APP_INC_DIRS ${APPS_ROOT_DIR}/machine/${MACHINE})
 
-# below is where demo config and compilation occurs
-collect(PROJECT_LIB_DEPS c)
-collect(PROJECT_LIB_DEPS m)
-collect(PROJECT_LIB_DEPS metal)
-collect(PROJECT_LIB_DEPS open_amp)
+  collector_list (_list PROJECT_INC_DIRS)
+  collector_list (_app_list APP_INC_DIRS)
 
-collect (APP_COMMON_SOURCES "${APPS_ROOT_DIR}/examples/${OPENAMP_APP_NAME}/${_app}.c")
-collect (APP_COMMON_SOURCES "${APPS_ROOT_DIR}/examples/${OPENAMP_APP_NAME}/${PROJECT_SYSTEM}/main.c")
-collector_list (_sources APP_COMMON_SOURCES)
+  include_directories (${_list} ${_app_list})
+  include_directories (${APPS_ROOT_DIR}/examples/legacy_apps/include)
+  link_directories (${_list} ${_app_list})
 
-collector_list (_app_list APP_INC_DIRS)
-collector_list (_list PROJECT_INC_DIRS)
-include_directories (${_list} ${_app_list} ${APPS_ROOT_DIR} ${APPS_ROOT_DIR}/system/${PROJECT_SYSTEM}/machine/${PROJECT_MACHINE}/)
-collector_list (_list PROJECT_LIB_DIRS)
-collector_list (_app_list APP_LIB_DIRS)
-link_directories (${_list} ${_app_list} ${APPS_ROOT_DIR}/system/${PROJECT_SYSTEM}/machine/${PROJECT_MACHINE}/)
-# UserConfig.cmake is file generated by Vitis-Unified workspace for applications.
-include(${CMAKE_SOURCE_DIR}/UserConfig.cmake)
-set (executable_name ${CMAKE_PROJECT_NAME})
-add_executable (${executable_name}.elf ${_sources})
-set_source_files_properties(${_sources} PROPERTIES COMPILE_FLAGS "${_cflags}")
+  get_property (_linker_opt GLOBAL PROPERTY APP_LINKER_OPT)
 
-get_property (LINKER_METADATA_FILE GLOBAL PROPERTY LINKER_METADATA_FILE)
-get_property (SOC GLOBAL PROPERTY SOC)
-set (SOCS ZYNQMP VERSAL)
-set (LOPPER_CFG_LINKERS lscript_r5.ld.in lscript_versal_r5.ld.in)
+  # below is where demo config and compilation occurs
+  collect(PROJECT_LIB_DEPS c)
+  collect(PROJECT_LIB_DEPS m)
+  collect(PROJECT_LIB_DEPS metal)
+  collect(PROJECT_LIB_DEPS open_amp)
 
-list(FIND SOCS "${SOC}" soc_index)
+  collect (APP_COMMON_SOURCES "${APPS_ROOT_DIR}/examples/${OPENAMP_APP_NAME}/${_app}.c")
+  collect (APP_COMMON_SOURCES "${APPS_ROOT_DIR}/examples/${OPENAMP_APP_NAME}/${PROJECT_SYSTEM}/main.c")
+  collector_list (_sources APP_COMMON_SOURCES)
 
-# AMD-Xilinx SDT workflow has split up libxil. Below are required libs
-# That were previously in libxil.
-collect(PROJECT_LIB_DEPS xil)
-collect(PROJECT_LIB_DEPS xiltimer)
-collect(PROJECT_LIB_DEPS xilstandalone)
+  collector_list (_app_list APP_INC_DIRS)
+  collector_list (_list PROJECT_INC_DIRS)
+  include_directories (${_list} ${_app_list} ${APPS_ROOT_DIR} ${APPS_ROOT_DIR}/system/${PROJECT_SYSTEM}/machine/${PROJECT_MACHINE}/)
+  collector_list (_list PROJECT_LIB_DIRS)
+  collector_list (_app_list APP_LIB_DIRS)
+  link_directories (${_list} ${_app_list} ${APPS_ROOT_DIR}/system/${PROJECT_SYSTEM}/machine/${PROJECT_MACHINE}/)
+  # UserConfig.cmake is file generated by Vitis-Unified workspace for applications.
+  include(${CMAKE_SOURCE_DIR}/UserConfig.cmake)
+  set (executable_name ${CMAKE_PROJECT_NAME})
+  add_executable (${executable_name}.elf ${_sources})
+  set_source_files_properties(${_sources} PROPERTIES COMPILE_FLAGS "${_cflags}")
 
-if (EXISTS ${LINKER_METADATA_FILE})
-  include(${LINKER_METADATA_FILE})
-  list (GET LOPPER_CFG_LINKERS ${soc_index} linker_in)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/linker_files/${linker_in} "${CMAKE_CURRENT_SOURCE_DIR}/lscript.ld")
-  list(APPEND LINKER_FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${linker_in})
-  list(APPEND LINKER_FILE ${linker_in})
-  set (_linker_script "${CMAKE_CURRENT_SOURCE_DIR}/lscript.ld")
-  message("Using LINKER_METADATA_FILE: ${LINKER_METADATA_FILE}")
-  set (_linker_opt "-Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_script}\"")
-else()
-  message(FATAL_ERROR "Could not find linker meta data file")
-endif(EXISTS ${LINKER_METADATA_FILE})
+  get_property (LINKER_METADATA_FILE GLOBAL PROPERTY LINKER_METADATA_FILE)
+  get_property (SOC GLOBAL PROPERTY SOC)
+  set (SOCS ZYNQMP VERSAL)
+  set (LOPPER_CFG_LINKERS lscript_r5.ld.in lscript_versal_r5.ld.in)
 
-collector_list (_deps PROJECT_LIB_DEPS)
+  list(FIND SOCS "${SOC}" soc_index)
 
-# Enable user to pass in extra linker flags
-if (DEFINED DEMO_LINK_FLAGS)
-  set (_deps "${_deps} ${DEMO_LINK_FLAGS}")
-endif(DEFINED DEMO_LINK_FLAGS)
+  # AMD-Xilinx SDT workflow has split up libxil. Below are required libs
+  # That were previously in libxil.
+  collect(PROJECT_LIB_DEPS xil)
+  collect(PROJECT_LIB_DEPS xiltimer)
+  collect(PROJECT_LIB_DEPS xilstandalone)
 
-target_link_libraries(${executable_name}.elf -Wl,-Map=${executable_name}.map -L${CMAKE_LIBRARY_PATH} -L${USER_LINK_DIRECTORIES}  -Wl,--gc-sections ${_linker_opt} -Wl,--start-group ${OPENAMP_LIB} ${_deps} -Wl,--end-group)
-target_compile_definitions(${executable_name}.elf PUBLIC ${USER_COMPILE_DEFINITIONS})
-install (TARGETS ${executable_name}.elf RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  if (EXISTS ${LINKER_METADATA_FILE})
+    include(${LINKER_METADATA_FILE})
+    list (GET LOPPER_CFG_LINKERS ${soc_index} linker_in)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/linker_files/${linker_in} "${CMAKE_CURRENT_SOURCE_DIR}/lscript.ld")
+    list(APPEND LINKER_FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${linker_in})
+    list(APPEND LINKER_FILE ${linker_in})
+    set (_linker_script "${CMAKE_CURRENT_SOURCE_DIR}/lscript.ld")
+    message("Using LINKER_METADATA_FILE: ${LINKER_METADATA_FILE}")
+    set (_linker_opt "-Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_script}\"")
+  else()
+    message(FATAL_ERROR "Could not find linker meta data file")
+  endif(EXISTS ${LINKER_METADATA_FILE})
+
+  collector_list (_deps PROJECT_LIB_DEPS)
+
+  # Enable user to pass in extra linker flags
+  if (DEFINED DEMO_LINK_FLAGS)
+    set (_deps "${_deps} ${DEMO_LINK_FLAGS}")
+  endif(DEFINED DEMO_LINK_FLAGS)
+
+  target_link_libraries(${executable_name}.elf -Wl,-Map=${executable_name}.map -L${CMAKE_LIBRARY_PATH} -L${USER_LINK_DIRECTORIES}  -Wl,--gc-sections ${_linker_opt} -Wl,--start-group ${OPENAMP_LIB} ${_deps} -Wl,--end-group)
+  target_compile_definitions(${executable_name}.elf PUBLIC ${USER_COMPILE_DEFINITIONS})
+  install (TARGETS ${executable_name}.elf RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+endif() #_vitis_build


### PR DESCRIPTION
OPENAMP_APP_NAME variable is needed for xilinx specific build tools. Native cmake build doesn't need this variable, and so if it's not found then do not fail, and include project machine direcotry. This allows native cmake build to continue.