### PR TITLE
Fix: avoid reuse of resource table between remote app activations

### DIFF
--- a/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
+++ b/examples/legacy_apps/machine/xlnx/zynqmp_r5/platform_info.c
@@ -415,7 +415,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 	struct metal_io_region *shbuf_io;
 	int ret;
 
-	restore_initial_rsc_table();
+	// restore_initial_rsc_table();
 
 	rpmsg_vdev = metal_allocate_memory(sizeof(*rpmsg_vdev));
 	if (!rpmsg_vdev)


### PR DESCRIPTION
Solves #109 

This fix has been tested on Kria KR260 with `rpmsg-echo` bare metal application.

